### PR TITLE
Remove Useless "pragma translaste_on"

### DIFF
--- a/rtl/src/common/hpdcache_fifo_reg_initialized.sv
+++ b/rtl/src/common/hpdcache_fifo_reg_initialized.sv
@@ -141,7 +141,6 @@ module hpdcache_fifo_reg_initialized
     rptr_ahead_wptr_assert: assert property (@(posedge clk_i) disable iff (~rst_ni)
             ((rptr_q <= wptr_q) && !crossover_q) || ((rptr_q >= wptr_q) && crossover_q)) else
             $error("fifo: read pointer is ahead of the write pointer");
-    //  pragma translate_on
 `endif
     //  }}}
 

--- a/rtl/src/hpdcache_wbuf_wrapper.sv
+++ b/rtl/src/hpdcache_wbuf_wrapper.sv
@@ -208,7 +208,6 @@ import hpdcache_pkg::*;
         initial assert(WBUF_MEM_DATA_RATIO > 0) else
                 $error($sformatf("WBUF: data width of mem interface (%d) shall be g.e. to wbuf data width(%d)",
                                  HPDcacheMemDataWidth, HPDCACHE_WBUF_DATA_WIDTH));
-        //  pragma translate_on
 `endif
         //  }}}
     endgenerate


### PR DESCRIPTION
Hello @cfuguet,

I believe some "pragma" were not removed in a3eb2b2b00f4da3ef1cbce1244a53b78e7f2d69c
It causes error with Synopsys DC_shell during synthesis