### PR TITLE
Add bender manifest file

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -1,0 +1,44 @@
+package:
+  name: hpdcache
+  authors:
+    - "César Fuguet <cesar.fuguettortolero@cea.fr>"
+
+export_include_dirs:
+  - rtl/include
+
+sources:
+  - rtl/src/hpdcache_pkg.sv
+  - rtl/src/common/hpdcache_demux.sv
+  - rtl/src/common/hpdcache_lfsr.sv
+  - rtl/src/common/hpdcache_sync_buffer.sv
+  - rtl/src/common/hpdcache_fifo_reg.sv
+  - rtl/src/common/hpdcache_fifo_reg_initialized.sv
+  - rtl/src/common/hpdcache_fxarb.sv
+  - rtl/src/common/hpdcache_rrarb.sv
+  - rtl/src/common/hpdcache_mux.sv
+  - rtl/src/common/hpdcache_prio_1hot_encoder.sv
+  - rtl/src/common/hpdcache_sram.sv
+  - rtl/src/common/hpdcache_sram_wbyteenable.sv
+  - rtl/src/common/hpdcache_sram_wmask.sv
+  - rtl/src/common/hpdcache_regbank_wbyteenable_1rw.sv
+  - rtl/src/common/hpdcache_regbank_wmask_1rw.sv
+  - rtl/src/common/hpdcache_data_downsize.sv
+  - rtl/src/common/hpdcache_data_upsize.sv
+  - rtl/src/hwpf_stride/hwpf_stride_pkg.sv
+  - rtl/src/hwpf_stride/hwpf_stride.sv
+  - rtl/src/hwpf_stride/hwpf_stride_arb.sv
+  - rtl/src/hwpf_stride/hwpf_stride_wrapper.sv
+  - rtl/src/hpdcache.sv
+  - rtl/src/hpdcache_amo.sv
+  - rtl/src/hpdcache_cmo.sv
+  - rtl/src/hpdcache_core_arbiter.sv
+  - rtl/src/hpdcache_ctrl.sv
+  - rtl/src/hpdcache_ctrl_pe.sv
+  - rtl/src/hpdcache_memctrl.sv
+  - rtl/src/hpdcache_miss_handler.sv
+  - rtl/src/hpdcache_mshr.sv
+  - rtl/src/hpdcache_plru.sv
+  - rtl/src/hpdcache_rtab.sv
+  - rtl/src/hpdcache_uncached.sv
+  - rtl/src/hpdcache_victim_sel.sv
+  - rtl/src/hpdcache_wbuf.sv


### PR DESCRIPTION
This PR adds a bender manifest file to the root directory of this repository.

Bender is a tool for managing dependencies in hardware projects: https://github.com/pulp-platform/bender

The manifest file defines the sources and dependencies of a project. It starts by defining a package, stating its name and its authors. By convention the package name should be in lowercase letters. I have used the name and mail address from the HPDcache paper, please let me know if I should change this or add further authors.

Since this repository does not have any dependencies, the Bender manifest only lists the source files. I have listed the sources from [`rtl/hpdcache.Flist`](https://github.com/openhwgroup/cv-hpdcache/blob/master/rtl/hpdcache.Flist) in the exact same order.

With this manifest file, bender can be used to emit tool scripts for processing these sources with various tools. For instance, executing the command

    bender script vcs

from within this repository emits a script that elaborates the sources using the `vlogan` command of VCS.

It is also possible to simply emit a file list, as the one in [`rtl/hpdcache.Flist`](https://github.com/openhwgroup/cv-hpdcache/blob/master/rtl/hpdcache.Flist), with

    bender script flist

Source files can also be listed under a target, in which case they are only added if that target is specified when invoking bender. One possible usage is to add testbench sources only when the target `simulation` is defined. The [Bender manifest of CVA6](https://github.com/openhwgroup/cva6/blob/master/Bender.yml) uses targets for the various different configurations.

I see that this project has target-specific files under `rtl/src/target/`, e.g., [`cva6_op_hpdcache_params_pkg.sv`](https://github.com/openhwgroup/cv-hpdcache/blob/master/rtl/src/target/cva6/cva6_op_hpdcache_params_pkg.sv), which is currently not listed in the [`rtl/hpdcache.Flist`](https://github.com/openhwgroup/cv-hpdcache/blob/master/rtl/hpdcache.Flist) and which I have not added to the Bender manifest. Please let me know if you would like to have that file added as well under a specific target.

A main advantage is that with the addition of this manifest file the HPDcache can be used in other HW projects by listing it as a dependency in another project's manifest file:

    dependencies:
      hpdcache:
        git: "https://github.com/openhwgroup/cv-hpdcache.git"
        version: v3.1.0

Note that `version` can either be the name of a branch or a tag. Bender will automatically check out the repository and read the manifest file to figure out which files it needs to use. Bender will also attempt to resolve potential conflicts in case a dependency is included multiple times within the dependency tree.