### PR TITLE
rtl: Make AXI transactions modifiable by default

### DIFF
--- a/rtl/src/utils/hpdcache_mem_to_axi_read.sv
+++ b/rtl/src/utils/hpdcache_mem_to_axi_read.sv
@@ -60,7 +60,7 @@ import hpdcache_pkg::*;
                     axi_pkg::CACHE_BUFFERABLE |
                     axi_pkg::CACHE_MODIFIABLE |
                     axi_pkg::CACHE_RD_ALLOC   |
-                    axi_pkg::CACHE_WR_ALLOC   : '0;
+                    axi_pkg::CACHE_WR_ALLOC   : axi_pkg::CACHE_MODIFIABLE;
 
     always_comb
     begin : resp_decode_comb

--- a/rtl/src/utils/hpdcache_mem_to_axi_write.sv
+++ b/rtl/src/utils/hpdcache_mem_to_axi_write.sv
@@ -106,7 +106,7 @@ import hpdcache_pkg::*;
                         axi_pkg::CACHE_BUFFERABLE |
                         axi_pkg::CACHE_MODIFIABLE |
                         axi_pkg::CACHE_RD_ALLOC   |
-                        axi_pkg::CACHE_WR_ALLOC   : '0;
+                        axi_pkg::CACHE_WR_ALLOC   : axi_pkg::CACHE_MODIFIABLE;
 
     always_comb
     begin : resp_decode_comb


### PR DESCRIPTION
The `modifiable` bit of `ax.cache` indicates whether an AXI transaction can be changed downstream.
This is needed by systems connecting to a low performance bus subsystem, e.g. a peripheral subsystem where the transaction is, e.g., split.

The same was done for the the other caches available in cva6 (https://github.com/openhwgroup/cva6/pull/948)