### PR TITLE
Fix cast int' into unsigned' when required

### DIFF
--- a/rtl/src/common/hpdcache_mux.sv
+++ b/rtl/src/common/hpdcache_mux.sv
@@ -70,7 +70,7 @@ module hpdcache_mux
         begin : data_out_mux_comb
             data_o = '0;
             for (int unsigned i = 0; i < NINPUT; i++) begin
-                data_o |= (i == int'(sel_i)) ? data_i[i] : '0;
+                data_o |= (i == unsigned'(sel_i)) ? data_i[i] : '0;
             end
         end
     end

--- a/rtl/src/hpdcache_core_arbiter.sv
+++ b/rtl/src/hpdcache_core_arbiter.sv
@@ -166,7 +166,7 @@ import hpdcache_pkg::*;
     always_comb
     begin : resp_demux
         for (int unsigned i = 0; i < HPDcacheCfg.u.nRequesters; i++) begin
-            core_rsp_valid_o[i]  = core_rsp_valid_i && (i == int'(core_rsp_i.sid));
+            core_rsp_valid_o[i]  = core_rsp_valid_i && (i == unsigned'(core_rsp_i.sid));
             core_rsp_o[i]        = core_rsp_i;
         end
     end

--- a/rtl/src/hpdcache_mshr.sv
+++ b/rtl/src/hpdcache_mshr.sv
@@ -153,7 +153,7 @@ import hpdcache_pkg::*;
 
         found_available_way = 0;
         for (int unsigned i = 0; i < HPDcacheCfg.u.mshrWays; i++) begin
-            if (!mshr_valid_q[i*HPDcacheCfg.u.mshrSets + int'(alloc_set)]) begin
+            if (!mshr_valid_q[i*HPDcacheCfg.u.mshrSets + unsigned'(alloc_set)]) begin
                 found_available_way = mshr_way_t'(i);
                 break;
             end
@@ -168,7 +168,7 @@ import hpdcache_pkg::*;
 
         found_available = 1'b0;
         for (int unsigned i = 0; i < HPDcacheCfg.u.mshrWays; i++) begin
-            if (!mshr_valid_q[i*HPDcacheCfg.u.mshrSets + int'(check_set_st1)]) begin
+            if (!mshr_valid_q[i*HPDcacheCfg.u.mshrSets + unsigned'(check_set_st1)]) begin
                 found_available = 1'b1;
                 break;
             end
@@ -249,8 +249,8 @@ import hpdcache_pkg::*;
             automatic bit v_valid;
             automatic bit v_match_set;
             automatic bit v_match_tag;
-            v_valid = mshr_valid_q[w*HPDcacheCfg.u.mshrSets + int'(check_set_st1)];
-            v_match_set = (mshr_cache_set_q[w*HPDcacheCfg.u.mshrSets + int'(check_set_st1)] ==
+            v_valid = mshr_valid_q[w*HPDcacheCfg.u.mshrSets + unsigned'(check_set_st1)];
+            v_match_set = (mshr_cache_set_q[w*HPDcacheCfg.u.mshrSets + unsigned'(check_set_st1)] ==
                           check_cache_set_q);
             v_match_tag = (mshr_rentry[w].tag == check_tag_i);
             v_hit_way[w] = (v_valid && v_match_tag && v_match_set);
@@ -286,7 +286,7 @@ import hpdcache_pkg::*;
         always_comb
         begin : mshr_wbyteenable_comb
             for (int unsigned i = 0; i < HPDcacheCfg.u.mshrWays; i++) begin
-                mshr_wbyteenable[i] = (int'(alloc_way_o) == i) ? '1 : '0;
+                mshr_wbyteenable[i] = (unsigned'(alloc_way_o) == i) ? '1 : '0;
             end
         end
 
@@ -327,7 +327,7 @@ import hpdcache_pkg::*;
         always_comb
         begin : mshr_wmask_comb
             for (int unsigned i = 0; i < HPDcacheCfg.u.mshrWays; i++) begin
-                mshr_wmask[i] = (int'(alloc_way_o) == i) ? '1 : '0;
+                mshr_wmask[i] = (unsigned'(alloc_way_o) == i) ? '1 : '0;
             end
         end
 

--- a/rtl/src/hpdcache_wbuf.sv
+++ b/rtl/src/hpdcache_wbuf.sv
@@ -277,7 +277,7 @@ import hpdcache_pkg::*;
             always_comb
             begin : wbuf_write_be_comb
                 for (int unsigned w = 0; w < WBUF_DATA_NWORDS; w++) begin
-                    if (w == int'(write_addr_i[WBUF_OFFSET_WIDTH-1:WBUF_WORD_OFFSET])) begin
+                    if (w == unsigned'(write_addr_i[WBUF_OFFSET_WIDTH-1:WBUF_WORD_OFFSET])) begin
                         write_be[w] = write_be_i;
                     end else begin
                         write_be[w] = '0;
@@ -485,7 +485,7 @@ import hpdcache_pkg::*;
                 end
 
                 WBUF_OPEN: begin
-                    match_open_ptr  = (i == int'(wbuf_write_hit_open_dir_ptr));
+                    match_open_ptr  = (i == unsigned'(wbuf_write_hit_open_dir_ptr));
                     timeout         = (wbuf_dir_q[i].cnt == (cfg_threshold_i - 1));
                     read_hit        = read_flush_hit_i & wbuf_write_hit_open & match_open_ptr;
                     write_hit       = write_i
@@ -521,7 +521,7 @@ import hpdcache_pkg::*;
                 end
 
                 WBUF_PEND: begin
-                    match_pend_ptr = (i == int'(wbuf_write_hit_pend_dir_ptr));
+                    match_pend_ptr = (i == unsigned'(wbuf_write_hit_pend_dir_ptr));
                     write_hit = write_i
                                 & wbuf_write_hit_pend
                                 & match_pend_ptr
@@ -544,7 +544,7 @@ import hpdcache_pkg::*;
                 end
 
                 WBUF_SENT: begin
-                    if (mem_resp_write_valid_i && (i == int'(ack_id))) begin
+                    if (mem_resp_write_valid_i && (i == unsigned'(ack_id))) begin
                         wbuf_dir_state_d[i] = WBUF_FREE;
                     end
                 end

--- a/rtl/src/hwpf_stride/hwpf_stride_arb.sv
+++ b/rtl/src/hwpf_stride/hwpf_stride_arb.sv
@@ -112,7 +112,7 @@ import hpdcache_pkg::*;
     always_comb
     begin : resp_demux
         for (int unsigned i = 0; i < NUM_HW_PREFETCH; i++) begin
-            hwpf_stride_rsp_valid_o[i]  = hpdcache_rsp_valid_i && (i == int'(hpdcache_rsp_i.tid));
+            hwpf_stride_rsp_valid_o[i]  = hpdcache_rsp_valid_i && (i == unsigned'(hpdcache_rsp_i.tid));
             hwpf_stride_rsp_o[i]        = hpdcache_rsp_i;
         end
     end

--- a/rtl/src/utils/hpdcache_to_l15.sv
+++ b/rtl/src/utils/hpdcache_to_l15.sv
@@ -363,7 +363,7 @@ module hpdcache_to_l15 import hpdcache_pkg::*; import wt_cache_pkg::*;
     always_comb
     begin: lzc_comb
         first_one_pos = '0;
-        for (int unsigned i = int'(HPDcacheMemDataWidth/8); i > 0; i--) begin
+        for (int unsigned i = unsigned'(HPDcacheMemDataWidth/8); i > 0; i--) begin
             if (req_wbe[i-1]) begin
                 first_one_pos = i-1;
                 break;


### PR DESCRIPTION
Replace all cast of `int'` by `unsigned' `when variable to be compared is of type `int unsigned`.

Xilinx's vivado would do wrong optimization in some corner cases. See image : 
![hpdcache_mux](https://github.com/user-attachments/assets/6bd09989-a639-44eb-9b4d-92cff6570c29)

This PR is not based on master. It would be great to have it on an updated v4.0.0 release since CVA6 use [Commit b4519e7 ](https://github.com/Gchauvon/cv-hpdcache/commit/b4519e767fb851ff3314d5e01d0542a04d9bbd3a)