### PR TITLE
mshr: Prevent assertion misfire during reset

### DIFF
--- a/rtl/src/hpdcache_mshr.sv
+++ b/rtl/src/hpdcache_mshr.sv
@@ -402,7 +402,7 @@ import hpdcache_pkg::*;
     //  Assertions
     //  {{{
 `ifndef HPDCACHE_ASSERT_OFF
-    one_command_assert: assert property (@(posedge clk_i)
+    one_command_assert: assert property (@(posedge clk_i) disable iff (rst_ni !== 1'b1)
             (ack_i -> !(alloc_i || check_i))) else
             $error("MSHR: ack with concurrent alloc or check");
 `endif


### PR DESCRIPTION
While the cache is held in reset, the `one_command_assert` assertion in `hpdcache_mshr` will always fail, raising a false-positive error any time the cache is being reset:

```
# ** Error: MSHR: ack with concurrent alloc or check
```

This should not happen as the reported error is not an actual issue. Furthermore, it presents a problem for testing setups designed to fail on assertion failures, as any meaningful simulation will trigger this assertion.

The proposed fix masks the assertion during reset with the `disable iff` clause.