### PR TITLE
evt: on WB miss with error, set the write event when resp to the core

### DIFF
--- a/rtl/src/hpdcache_ctrl_pe.sv
+++ b/rtl/src/hpdcache_ctrl_pe.sv
@@ -405,6 +405,9 @@ module hpdcache_ctrl_pe
                     st1_rtab_commit_o = st1_req_rtab_i;
                     st1_rsp_valid_o = st1_req_need_rsp_i;
                     st1_rsp_error_o = st1_req_need_rsp_i;
+
+                    //  Performance event
+                    evt_write_req_o = st1_req_is_store_i;
                 end
 
                 //  Allocate a new entry in the replay table in case of conflict with


### PR DESCRIPTION
This bug concerns the performance event signals. No impact on the normal operation of the cache.

It fixes issue #47