### PR TITLE
Add support for responses for CMO operations

### DIFF
--- a/rtl/src/hpdcache.sv
+++ b/rtl/src/hpdcache.sv
@@ -277,7 +277,10 @@ import hpdcache_pkg::*;
     logic                  cmo_ready;
     hpdcache_cmoh_op_t     cmo_req_op;
     hpdcache_req_addr_t    cmo_req_addr;
+    hpdcache_req_sid_t     cmo_req_sid;
+    hpdcache_req_tid_t     cmo_req_tid;
     hpdcache_req_data_t    cmo_req_wdata;
+    logic                  cmo_req_need_rsp;
     logic                  cmo_wbuf_flush_all;
     logic                  cmo_dir_check_nline;
     hpdcache_set_t         cmo_dir_check_nline_set;
@@ -297,6 +300,9 @@ import hpdcache_pkg::*;
     logic                  cmo_flush_alloc;
     hpdcache_nline_t       cmo_flush_alloc_nline;
     hpdcache_way_vector_t  cmo_flush_alloc_way;
+    logic                  cmo_core_rsp_ready;
+    logic                  cmo_core_rsp_valid;
+    hpdcache_rsp_t         cmo_core_rsp;
 
     logic                  flush_empty;
     logic                  flush_busy;
@@ -585,6 +591,9 @@ import hpdcache_pkg::*;
         .cmo_req_op_o                       (cmo_req_op),
         .cmo_req_addr_o                     (cmo_req_addr),
         .cmo_req_wdata_o                    (cmo_req_wdata),
+        .cmo_req_sid_o                      (cmo_req_sid),
+        .cmo_req_tid_o                      (cmo_req_tid),
+        .cmo_req_need_rsp_o                 (cmo_req_need_rsp),
         .cmo_wbuf_flush_all_i               (cmo_wbuf_flush_all),
         .cmo_dir_check_nline_i              (cmo_dir_check_nline),
         .cmo_dir_check_nline_set_i          (cmo_dir_check_nline_set),
@@ -600,6 +609,9 @@ import hpdcache_pkg::*;
         .cmo_dir_inval_i                    (cmo_dir_inval),
         .cmo_dir_inval_set_i                (cmo_dir_inval_set),
         .cmo_dir_inval_way_i                (cmo_dir_inval_way),
+        .cmo_core_rsp_ready_o               (cmo_core_rsp_ready),
+        .cmo_core_rsp_valid_i               (cmo_core_rsp_valid),
+        .cmo_core_rsp_i                     (cmo_core_rsp),
 
         .rtab_empty_o                       (rtab_empty),
         .ctrl_empty_o                       (ctrl_empty),
@@ -879,16 +891,19 @@ import hpdcache_pkg::*;
     //  CMO Request Handler
     //  {{{
     hpdcache_cmo #(
-      .HPDcacheCfg                     (HPDcacheCfg),
+        .HPDcacheCfg                   (HPDcacheCfg),
 
-      .hpdcache_nline_t                (hpdcache_nline_t),
-      .hpdcache_tag_t                  (hpdcache_tag_t),
-      .hpdcache_set_t                  (hpdcache_set_t),
-      .hpdcache_data_word_t            (hpdcache_data_word_t),
-      .hpdcache_way_vector_t           (hpdcache_way_vector_t),
+        .hpdcache_nline_t              (hpdcache_nline_t),
+        .hpdcache_tag_t                (hpdcache_tag_t),
+        .hpdcache_set_t                (hpdcache_set_t),
+        .hpdcache_data_word_t          (hpdcache_data_word_t),
+        .hpdcache_way_vector_t         (hpdcache_way_vector_t),
 
-      .hpdcache_req_addr_t             (hpdcache_req_addr_t),
-      .hpdcache_req_data_t             (hpdcache_req_data_t)
+        .hpdcache_rsp_t                (hpdcache_rsp_t),
+        .hpdcache_req_addr_t           (hpdcache_req_addr_t),
+        .hpdcache_req_tid_t            (hpdcache_req_tid_t),
+        .hpdcache_req_sid_t            (hpdcache_req_sid_t),
+        .hpdcache_req_data_t           (hpdcache_req_data_t)
     ) hpdcache_cmo_i(
         .clk_i,
         .rst_ni,
@@ -903,7 +918,14 @@ import hpdcache_pkg::*;
         .req_op_i                      (cmo_req_op),
         .req_addr_i                    (cmo_req_addr),
         .req_wdata_i                   (cmo_req_wdata),
+        .req_sid_i                     (cmo_req_sid),
+        .req_tid_i                     (cmo_req_tid),
+        .req_need_rsp_i                (cmo_req_need_rsp),
         .req_wait_o                    (cmo_wait),
+
+        .core_rsp_ready_i              (cmo_core_rsp_ready),
+        .core_rsp_valid_o              (cmo_core_rsp_valid),
+        .core_rsp_o                    (cmo_core_rsp),
 
         .wbuf_flush_all_o              (cmo_wbuf_flush_all),
 

--- a/rtl/src/hpdcache_cmo.sv
+++ b/rtl/src/hpdcache_cmo.sv
@@ -243,13 +243,13 @@ import hpdcache_pkg::*;
 
         unique case (cmoh_fsm_q)
             CMOH_IDLE: begin
-                req_ready_o = ~core_rsp_send_q;
+                req_ready_o = ~core_rsp_rok | core_rsp_r;
 
                 if (core_rsp_r) begin
                     core_rsp_send_d = 1'b0;
                 end
 
-                else if (req_valid_i) begin
+                if (req_valid_i && req_ready_o) begin
                     core_rsp_w = req_need_rsp_i;
 
                     unique case (1'b1)

--- a/rtl/src/hpdcache_ctrl_pe.sv
+++ b/rtl/src/hpdcache_ctrl_pe.sv
@@ -178,6 +178,7 @@ module hpdcache_ctrl_pe
     input  logic                   cmo_busy_i,
     input  logic                   cmo_wait_i,
     output logic                   cmo_req_valid_o,
+    output logic                   cmo_core_rsp_ready_o,
     //   }}}
 
     //   Configuration
@@ -230,7 +231,8 @@ module hpdcache_ctrl_pe
 
     //  Arbitration of responses to the core
     //  {{{
-    assign uc_core_rsp_ready_o = ~refill_core_rsp_valid_i;
+    assign uc_core_rsp_ready_o  = ~refill_core_rsp_valid_i;
+    assign cmo_core_rsp_ready_o = ~refill_core_rsp_valid_i;
     //  }}}
 
     //  Replay logic

--- a/rtl/tb/hpdcache_test_scoreboard.h
+++ b/rtl/tb/hpdcache_test_scoreboard.h
@@ -429,9 +429,12 @@ private:
                     }
                 }
 #endif
-                //  release response ID on the sequence
-                seq->deallocate_id(req_id);
-                continue;
+
+                if (!req.req_need_rsp) {
+                    //  release response ID on the sequence
+                    seq->deallocate_id(req_id);
+                    continue;
+                }
             }
 
             bool hit = false;
@@ -469,7 +472,7 @@ private:
             }
 
             //  Look for the request address into the error memory segments
-            if (mem_resp_model) {
+            if (mem_resp_model && (!req.is_cmo() || req.is_cmo_prefetch())) {
                 e.is_error = mem_resp_model->within_error_region(e.addr, e.addr + e.bytes);
             }
 

--- a/rtl/tb/hpdcache_test_transaction.h
+++ b/rtl/tb/hpdcache_test_transaction.h
@@ -179,6 +179,12 @@ public:
                 (op == HPDCACHE_REQ_CMO_FLUSH_INVAL_ALL));
     }
 
+    bool is_cmo_prefetch() const
+    {
+        unsigned op = this->req_op.to_uint();
+        return (op == HPDCACHE_REQ_CMO_PREFETCH);
+    }
+
     static const char* op_to_string(unsigned int op)
     {
         switch (op) {

--- a/rtl/tb/sequence_lib/hpdcache_test_random_seq.h
+++ b/rtl/tb/sequence_lib/hpdcache_test_random_seq.h
@@ -218,7 +218,7 @@ private:
             t->req_be          = 0;
             t->req_size        = 0;
             t->req_uncacheable = false;
-            t->req_need_rsp    = false;
+            t->req_need_rsp    = true;
         } else {
             uint32_t offset = address % HPDCACHE_REQ_DATA_BYTES;
             t->req_be          = ((1UL << bytes) - 1) << offset;


### PR DESCRIPTION
With these modifications, the CMO handler in the HPDcache sends back a response for CMO requests where the need_rsp flag is asserted.

CMO responses are sent back to requesters when the corresponding operations are completed. This allows the requesters to know when the corresponding operation is completed. 