### PR TITLE
Handling tweaks for configs with clWords == accessWords and clWords == 1

### DIFF
--- a/rtl/src/hpdcache_miss_handler.sv
+++ b/rtl/src/hpdcache_miss_handler.sv
@@ -259,7 +259,10 @@ import hpdcache_pkg::*;
     end
 
     localparam hpdcache_uint REFILL_REQ_SIZE = $clog2(HPDcacheCfg.u.memDataWidth / 8);
-    localparam hpdcache_uint REFILL_REQ_LEN = HPDcacheCfg.clWidth / HPDcacheCfg.u.memDataWidth;
+    localparam hpdcache_uint REFILL_REQ_LEN =
+        ( HPDcacheCfg.clWidth >= HPDcacheCfg.u.memDataWidth )
+        ? HPDcacheCfg.clWidth / HPDcacheCfg.u.memDataWidth
+        : 1;
 
     assign mem_req_o.mem_req_addr = {mshr_alloc_nline_q, {HPDcacheCfg.clOffsetWidth{1'b0}} };
     assign mem_req_o.mem_req_len = hpdcache_mem_len_t'(REFILL_REQ_LEN-1);

--- a/rtl/src/hpdcache_miss_handler.sv
+++ b/rtl/src/hpdcache_miss_handler.sv
@@ -143,8 +143,11 @@ import hpdcache_pkg::*;
     //  {{{
     localparam hpdcache_uint REFILL_REQ_RATIO = HPDcacheCfg.u.accessWords /
                                                 HPDcacheCfg.u.reqWords;
-    localparam hpdcache_uint REFILL_LAST_CHUNK_WORD = HPDcacheCfg.u.clWords -
-                                                      HPDcacheCfg.u.accessWords;
+
+    localparam hpdcache_uint REFILL_LAST_CHUNK_WORD =
+        (HPDcacheCfg.u.memDataWidth / HPDcacheCfg.u.wordWidth) > HPDcacheCfg.u.accessWords
+        ? (HPDcacheCfg.u.memDataWidth / HPDcacheCfg.u.wordWidth) - HPDcacheCfg.u.accessWords
+        : 0;
 
     typedef enum logic {
         MISS_REQ_IDLE = 1'b0,

--- a/rtl/src/hpdcache_pkg.sv
+++ b/rtl/src/hpdcache_pkg.sv
@@ -487,7 +487,7 @@ package hpdcache_pkg;
 
         ret.clWidth = p.clWords * p.wordWidth;
         ret.clOffsetWidth = $clog2(ret.clWidth / 8);
-        ret.clWordIdxWidth = $clog2(p.clWords);
+        ret.clWordIdxWidth = (p.clWords > 1) ? $clog2(p.clWords) : 1;
         ret.wordByteIdxWidth = $clog2(p.wordWidth / 8);
         ret.wayIndexWidth = (p.ways > 1) ? $clog2(p.ways) : 1;
         ret.setWidth = $clog2(p.sets);


### PR DESCRIPTION
Hi, I played around with the configuration parameters and found a few edge cases that I imagine *should* work but currently don't. `clWords == accessWords` hangs indefinitely if `memDataWidth > accessWidth` , seemingly because `REFILL_LAST_CHUNK_WORD == 0` which causes the `REFILL_WRITE` state to immediately jump to `REFILL_DIR`, which might cause the miss handler to never raise the `refill_core_rsp_valid` signal for certain request addresses. I really only have a passing familiarity with RTL design and `hpdcache`, but from what I can tell the resized input data is split into access-sized chunks that get serially processed by `REFILL_WRITE`, and the requested word gets sent to the core if we're processing the corresponding refill chunk. `REFILL_DIR` should only be used when we're dealing with a single chunk, but the situation I've described above causes us to enter `REFILL_DIR` with unprocessed chunks left. I changed `REFILL_LAST_CHUNK_WORD` to look at the memory data width instead to figure out when we're in the last chunk. Apologies if this is not correct, but please at least consider this a bug report :)

`clWords == 1` implies `accessWords == 1`, and I suppose such a config would be a rather extreme edge case but it does seem to work with only a small tweak.

I ran the small verilator tests in `rtl/tb` with the below config that causes a test failure without these patches:
```
CONF_HPDCACHE_PA_WIDTH=56
CONF_HPDCACHE_WORD_WIDTH=64
CONF_HPDCACHE_SETS=64
CONF_HPDCACHE_WAYS=4
CONF_HPDCACHE_CL_WORDS=1
CONF_HPDCACHE_REQ_WORDS=1
CONF_HPDCACHE_REQ_TRANS_ID_WIDTH=6
CONF_HPDCACHE_REQ_SRC_ID_WIDTH=3
CONF_HPDCACHE_VICTIM_SEL=HPDCACHE_VICTIM_PLRU
CONF_HPDCACHE_DATA_WAYS_PER_RAM_WORD=2
CONF_HPDCACHE_DATA_SETS_PER_RAM=$(CONF_HPDCACHE_SETS)
CONF_HPDCACHE_DATA_RAM_WBYTEENABLE=1
CONF_HPDCACHE_ACCESS_WORDS=1
CONF_HPDCACHE_MSHR_SETS=1
CONF_HPDCACHE_MSHR_WAYS=8
CONF_HPDCACHE_MSHR_WAYS_PER_RAM_WORD=$(CONF_HPDCACHE_MSHR_WAYS)
CONF_HPDCACHE_MSHR_SETS_PER_RAM=$(CONF_HPDCACHE_MSHR_SETS)
CONF_HPDCACHE_MSHR_RAM_WBYTEENABLE=1
CONF_HPDCACHE_MSHR_USE_REGBANK=1
CONF_HPDCACHE_REFILL_CORE_RSP_FEEDTHROUGH=1
CONF_HPDCACHE_REFILL_FIFO_DEPTH=3
CONF_HPDCACHE_WBUF_DIR_ENTRIES=8
CONF_HPDCACHE_WBUF_DATA_ENTRIES=4
CONF_HPDCACHE_WBUF_WORDS=2
CONF_HPDCACHE_WBUF_TIMECNT_WIDTH=3
CONF_HPDCACHE_WBUF_SEND_FEEDTHROUGH=0
CONF_HPDCACHE_RTAB_ENTRIES=4
CONF_HPDCACHE_FLUSH_ENTRIES=4
CONF_HPDCACHE_FLUSH_FIFO_DEPTH=2
CONF_HPDCACHE_MEM_ADDR_WIDTH=64
CONF_HPDCACHE_MEM_ID_WIDTH=4
CONF_HPDCACHE_MEM_DATA_WIDTH=512
CONF_HPDCACHE_WT_ENABLE=1
CONF_HPDCACHE_WB_ENABLE=1
```

The default config also passes with these patches applied.

Sidenote, the GitHub actions used by this project seem to only use the default config for testing, is the default intended to be a 'reasonable' configuration or an intentionally difficult one to deal with? I'm wondering if the action runners should be extended to test out a few different configurations, or is that the responsibility of the larger testsuite mentioned in the README? 