### PR TITLE
Fix error in the RTAB section of the documentation

### DIFF
--- a/docs/source/architecture.rst
+++ b/docs/source/architecture.rst
@@ -1000,7 +1000,11 @@ request (dependencies have been resolved) from the RTAB.
          //  Find a list whose head request is ready
          //  (using a round-robin policy)
          index = rtab_find_ready(last);
-         if (index == -1) return -1;
+
+         //  If there is no ready entry, or there is an ongoing rollback,
+         //  return an invalid index
+         if ((index == -1) || rtab_pop_rollback)
+           return -1;
 
          //  Update the pointer to the last linked list served
          last = index;
@@ -1019,6 +1023,12 @@ request (dependencies have been resolved) from the RTAB.
 
        case NEXT:
          index = next;
+
+         //  If there is an ongoing rollback, abandon the current pop
+         if (rtab_pop_rollback) {
+            pop_state = HEAD;
+            return -1;
+         }
 
          //  If the list have more than one request, the next time this function
          //  is called, serve the next request of the list


### PR DESCRIPTION
This PR fixes issue #60

The bug affected only the documentation. I reviewed the RTL code, and the behavior did not implement this bug (the model did not follow exactly the documentation). The documentation now better describes the RTL implementation.
