### PR TITLE
Fix potential timing loop in the memory write arbiter

### DIFF
--- a/rtl/src/utils/hpdcache_mem_req_write_arbiter.sv
+++ b/rtl/src/utils/hpdcache_mem_req_write_arbiter.sv
@@ -101,7 +101,6 @@ module hpdcache_mem_req_write_arbiter
 
     //  Read grant FIFO when the NoC is able to receive the data and it is the last flit of data
     assign mem_write_arb_req_r = mem_req_write_data_ready_i &
-                                 mem_write_arb_req_rok &
                                  req_data_valid &
                                  req_data_last;
 
@@ -147,7 +146,7 @@ module hpdcache_mem_req_write_arbiter
     //  {{{
     hpdcache_fifo_reg #(
         .FIFO_DEPTH    (2),
-        .FEEDTHROUGH   (1'b1),
+        .FEEDTHROUGH   (1'b0),
         .fifo_data_t   (arb_gnt_t)
     ) req_gnt_fifo_i(
         .clk_i,


### PR DESCRIPTION
If the subordinate device in the memory write interface makes the ready signal dependant to the valid signal, the write arbiter in the HPDcache has a timing loop.

This modification prevents this timing loop by disabling the feedthrough parameter in the grant FIFO.