### PR TITLE
Add configuration for ReadTheDocs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ VRMDATA/
 *.log
 *.wlf
 *.ucdb
+*.swp

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,24 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+# Copyright 2025 OpenHW Foundation
+# SPDX-License-Identifier:Apache-2.0 WITH SHL-2.1
+
+# Required
+version: 2
+
+# Set the OS, Python version, and other tools you might need
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.13"
+
+# Build documentation in the "docs/" directory with Sphinx
+sphinx:
+   configuration: docs/source/conf.py
+
+# Optionally, but recommended,
+# declare the Python requirements required to build your documentation
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+python:
+  install:
+    - requirements: docs/requirements.txt

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,6 +40,12 @@ A secondary build target is pdf. To build the pdf, additional prerequisites need
 sudo apt-get install texlive-latex-base
 ```
 
+Note: you may also need to install the `latexmk` package seperately.
+
+```bash
+sudo apt install latexmk
+```
+
 A pdf document can be built using the command
 
 ```bash

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,8 @@
+# Used by ReadTheDocs
+# Copyright 2025 OpenHW Foundation
+# SPDX-License-Identifier:Apache-2.0 WITH SHL-2.1
 sphinx
-sphinx-rtd-theme
+sphinx_rtd_theme
+recommonmark
+#sphinxcontrib-svg2pdfconverter
+#sphinx_github_changelog


### PR DESCRIPTION
The HTML documentation _should_ be visible at https://openhw-group-cv-hpdcache.readthedocs-hosted.com/en/latest/ once this PR is merged in.