### PR TITLE
fv.lnt : readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ The HPDcache is an open-source High-Performance, Multi-requester, Out-of-Order L
     <td>Contains a HPDcache standalone testbench for validation of the RTL</td>
   </tr>
   <tr>
+    <td>rtl/fv/lnt</td>
+    <td>Contains a formal HPDcache specification written in LNT</td>
+  </tr>
+  <tr>
     <td>docs</td>
     <td>Contains documentation of the HPDcache</td>
   </tr>

--- a/rtl/fv/lnt/README.md
+++ b/rtl/fv/lnt/README.md
@@ -8,15 +8,14 @@ These processes transmit the requests to each other using gates of channel type 
 In addition, all component synchronize on a dedicated 'STATUS' gate enabling the controller to atomically access the local states of all components.
 
 # Files
-- main.lnt: parallel composition of the HPDcache, along with a requester and a lower-level memory
-- hpdcache.lnt: parallel compositions of the components & specification of the controller component
-  (extraire le controller de hpdcache.lnt vers un module controller.lnt ?)
-- cachedata.lnt: cache memory component with local data types and functions
-- misshandler.lnt: miss handler component with local data types and functions
-- replaytable.lnt: replay table buffer component with local data types and functions
-- writebuffer.lnt: write buffer component with local data types and functions
-- types.lnt: common data types
-- channels.lnt: common channels (gate types)
+- `main.lnt` : parallel composition of the HPDcache, along with a requester and a lower-level memory
+- `hpdcache.lnt` : parallel compositions of the components & specification of the controller component
+- `cachedata.lnt` : cache memory component with local data types and functions
+- `misshandler.lnt` : miss handler component with local data types and functions
+- `replaytable.lnt` : replay table buffer component with local data types and functions
+- `writebuffer.lnt` : write buffer component with local data types and functions
+- `types.lnt` : common data types
+- `channels.lnt` : common channels (gate types)
 
 # Features
 ## Implemented features
@@ -41,22 +40,21 @@ The model parameters are configurable, by altering type or function definitions 
   - function X_NENTRIES is return N ...
   - for X = Memory in addtion: `type Addr is NoAddr, A1, A2,` ... `AN`
   - for X = Cache in addition: `type LRU_t is array [1..N] of Bool`
-  (attention aux indices des tableaux : ce n'est pas toujours 1..N, mais parfois 0..N-1 ! Voila, la raison d'unifier : faciliter l'explication)
 - number of requesters :
   - *types.lnt* : `type SId is range 1..N of nat`...
   - *main.lnt* : add new `|| CRI_REQ, CRI_RSP_R, CRI_RSP_W -> CORE [...] (K of SId)`s in the MAIN process parallel composition, with distinct SIds (denoted "K" above) from 1 to N.
-  (attention : les CORE ne doivent pas se synchroniser entre exu : il faut un par ... end par en plus)
 - enable/disable the documentation fix from v5.0.1 (module replaytable.lnt): modify (constant) function fixed
 
 # Simulation and Verification
 This formal LNT model can be simulated and verified using the [CADP toolbox](https://cadp.inria.fr/).
 
 # References
-## [1] H. Garavel, F. Lang and W. Serwe.
+- [1] H. Garavel, F. Lang and W. Serwe.
        From LOTOS to LNT.
        In: ModelEd, TestEd, TrustEd-Essays Dedicated to Ed Brinksma on the Occasion of His 60th Birthday.
        Lecture Notes in Computer Science, volume 10500, pp. 3-26, Springer Verlag, 2017.
-## [2] H. Garavel, F. Lang, R. Mateescu and W. Serwe.
+
+- [2] H. Garavel, F. Lang, R. Mateescu and W. Serwe.
        CADP 2011: A Toolbox for the Construction and Analysis of Distributed Processes.
        Springer International Journal on Software Tools for Technology Transfer 15(2):89-107, 2013.
        https://cadp.inria.fr


### PR DESCRIPTION
fixed the fv/lnt README file extension
added a row in the main README for the fv/lnt formal specification