### PR TITLE
syn: fix slang error on CMO handler FSM enum type

### DIFF
--- a/rtl/syn/tcl/yosys_synth.tcl
+++ b/rtl/syn/tcl/yosys_synth.tcl
@@ -11,6 +11,7 @@ source tcl/yosys_common.tcl
 yosys log "======== Yosys Parse RTL Sources ========"
 yosys read_slang -F ${param_filelist}
 yosys setattr -set top 1 ${param_top}
+yosys setattr -unset init
 yosys log "======== Yosys End Parse RTL Sources ========\n"
 
 yosys log "======== Yosys Parse Liberty Files ========"


### PR DESCRIPTION
This PR implements the solution proposed in https://github.com/povik/yosys-slang/issues/119. The proposed hotfix appears to solve the issue of the CMO handler enum type unexpectedly causing a failure in the synthesis CI. 