### PR TITLE
Fix gnt_index_t size definition to match 1hot_to_binary

### DIFF
--- a/rtl/src/utils/hpdcache_mem_req_read_arbiter.sv
+++ b/rtl/src/utils/hpdcache_mem_req_read_arbiter.sv
@@ -29,7 +29,7 @@ module hpdcache_mem_req_read_arbiter
 #(
     parameter int unsigned N = 0,
     parameter type hpdcache_mem_req_t = logic,
-    localparam type gnt_index_t = logic[(N > 1 ? $clog2(N) : 0):0]
+    localparam type gnt_index_t = logic[(N > 1 ? $clog2(N) - 1 : 0):0]
 )
 //  }}}
 


### PR DESCRIPTION
For the case with N > 1, gnt_index_t must be [log2(N)-1:0], otherwise it has 1 extra bit compared to 1hot_to_binary connection