### PR TITLE
rtl/tb/Makefile: make `nonregression` exit with error code if errors are found

### DIFF
--- a/rtl/tb/Makefile
+++ b/rtl/tb/Makefile
@@ -252,7 +252,8 @@ nonregression:
 	$(Q)$(SCANLOG) -pat scripts/scan_patterns/run_patterns.pat \
 	        -att scripts/scan_patterns/run_attributes.pat \
 	        -nowarn $(LOG_DIR)/nonreg_$(DATE_TIME)/$(SEQUENCE)_*.log \
-	        |& tee $(LOG_DIR)/nonreg_$(DATE_TIME)/nonreg.scan.log
+	        2>&1 | tee $(LOG_DIR)/nonreg_$(DATE_TIME)/nonreg.scan.log ; \
+	        exit $${PIPESTATUS[0]}
 
 .PHONY: cov
 cov: $(COV_MERGEFILE) $(COV_MERGEFILE).info


### PR DESCRIPTION
I noticed that a failing test in the ```nonregression``` target does not cause the CI to fail. I suspect that the ```tee``` invocation is masking the exit code of ```scanlog```. The proposed change results in a CI failure in my feature branch as expected.