### PR TITLE
test_scoreboard: model store invalidation of LR/SC reservation buffer

### DIFF
--- a/rtl/tb/Makefile
+++ b/rtl/tb/Makefile
@@ -252,7 +252,8 @@ nonregression:
 	$(Q)$(SCANLOG) -pat scripts/scan_patterns/run_patterns.pat \
 	        -att scripts/scan_patterns/run_attributes.pat \
 	        -nowarn $(LOG_DIR)/nonreg_$(DATE_TIME)/$(SEQUENCE)_*.log \
-	        |& tee $(LOG_DIR)/nonreg_$(DATE_TIME)/nonreg.scan.log
+	        2>&1 | tee $(LOG_DIR)/nonreg_$(DATE_TIME)/nonreg.scan.log ; \
+	        exit $${PIPESTATUS[0]}
 
 .PHONY: cov
 cov: $(COV_MERGEFILE) $(COV_MERGEFILE).info


### PR DESCRIPTION
Starting from the CI error highlighted in https://github.com/openhwgroup/cv-hpdcache/pull/104, I believe the root cause is the scoreboard modeling of a store operation invalidating the LR/SC reservation buffer. This PR generalizes the ```addr_match``` evaluation mimicking what happens also in RTL. The CI fix proposed in the aforementioned PR is included to show that the CI now passes.