### PR TITLE
testbench: replace fixed wait with inflight-based completion

### DIFF
--- a/rtl/tb/hpdcache_tb.cpp
+++ b/rtl/tb/hpdcache_tb.cpp
@@ -158,6 +158,7 @@ public:
         hpdcache_test_agent_i->core_rsp_i(core_rsp);
         hpdcache_test_agent_i->sb_core_req_o(sb_core_req);
         hpdcache_test_agent_i->sb_core_resp_o(sb_core_resp);
+        hpdcache_test_agent_i->no_inflight_requests_i(no_inflight_requests);
 
         hpdcache_test_mem_resp_model_i->clk_i(clk_i);
         hpdcache_test_mem_resp_model_i->rst_ni(rst_ni);
@@ -223,6 +224,7 @@ public:
         hpdcache_test_scoreboard_i->evt_rtab_rollback_i(evt_rtab_rollback);
         hpdcache_test_scoreboard_i->evt_stall_refill_i(evt_stall_refill);
         hpdcache_test_scoreboard_i->evt_stall_i(evt_stall);
+        hpdcache_test_scoreboard_i->no_inflight_requests_o(no_inflight_requests);
 
         seq->set_max_transactions(this->max_trans);
         seq->set_mem_resp_model(hpdcache_test_mem_resp_model_i);
@@ -425,6 +427,8 @@ private:
     sc_core::sc_signal<bool> evt_rtab_rollback;
     sc_core::sc_signal<bool> evt_stall_refill;
     sc_core::sc_signal<bool> evt_stall;
+    
+    sc_core::sc_signal<bool> no_inflight_requests;
 
     sc_core::sc_signal<bool> wbuf_empty;
 

--- a/rtl/tb/hpdcache_tb.cpp
+++ b/rtl/tb/hpdcache_tb.cpp
@@ -427,7 +427,7 @@ private:
     sc_core::sc_signal<bool> evt_rtab_rollback;
     sc_core::sc_signal<bool> evt_stall_refill;
     sc_core::sc_signal<bool> evt_stall;
-    
+
     sc_core::sc_signal<bool> no_inflight_requests;
 
     sc_core::sc_signal<bool> wbuf_empty;

--- a/rtl/tb/include/hpdcache_test_agent.h
+++ b/rtl/tb/include/hpdcache_test_agent.h
@@ -51,6 +51,8 @@ public:
     sc_in<bool> core_rsp_valid_i;
     sc_in<sc_bv<HPDCACHE_CORE_RSP_WIDTH>> core_rsp_i;
 
+    sc_in<bool> no_inflight_requests_i;
+
     sc_fifo_out<hpdcache_test_transaction_req> sb_core_req_o;
     sc_fifo_out<hpdcache_test_transaction_resp> sb_core_resp_o;
 
@@ -66,6 +68,7 @@ public:
       , core_rsp_i("core_rsp_i")
       , sb_core_req_o("sb_core_req_o")
       , sb_core_resp_o("sb_core_resp_o")
+      , no_inflight_requests_i("no_inflight_requests_i")
     {
         std::string driver_name;
 
@@ -87,6 +90,8 @@ public:
 
         driver->sb_core_req_o(sb_core_req_o);
         driver->sb_core_resp_o(sb_core_resp_o);
+
+        driver->no_inflight_requests_i(no_inflight_requests_i);
 
         driver->transaction_fifo_i(Agent::transaction_fifo);
         driver->transaction_ret_o(Agent::transaction_ret);

--- a/rtl/tb/include/hpdcache_test_driver.h
+++ b/rtl/tb/include/hpdcache_test_driver.h
@@ -181,7 +181,6 @@ private:
             wait();
         } while (!no_inflight_requests_i.read());
 
-
         Verilated::gotFinish(true);
     }
 

--- a/rtl/tb/include/hpdcache_test_driver.h
+++ b/rtl/tb/include/hpdcache_test_driver.h
@@ -38,6 +38,7 @@ public:
 
     sc_in<bool> core_rsp_valid_i;
     sc_in<sc_bv<HPDCACHE_CORE_RSP_WIDTH>> core_rsp_i;
+    sc_in<bool> no_inflight_requests_i;
 
     sc_fifo_out<hpdcache_test_transaction_req> sb_core_req_o;
     sc_fifo_out<hpdcache_test_transaction_resp> sb_core_resp_o;
@@ -176,9 +177,10 @@ private:
         // FIXME : I should find a better way to know when all transactions
         // have been completed. Otherwise, finish the simulation in a different
         // place (e.g. the scoreboard that knows all pending transactions)
-        for (int i = 0; i < 10000; i++) {
+        do {
             wait();
-        }
+        } while (!no_inflight_requests_i.read());
+
 
         Verilated::gotFinish(true);
     }

--- a/rtl/tb/include/hpdcache_test_scoreboard.h
+++ b/rtl/tb/include/hpdcache_test_scoreboard.h
@@ -377,12 +377,13 @@ private:
         if (evt_stall_i.read()) evt_stall++;
     }
 
-    void check_inflight_requests() {
-      const bool no_inflight = inflight_mem_write_m.empty() &&
-                               inflight_mem_read_m.empty() &&
-                               inflight_m.empty();
-    
-      no_inflight_requests_o.write(no_inflight);
+    void check_inflight_requests()
+    {
+
+        const bool no_inflight =
+            inflight_mem_write_m.empty() && inflight_mem_read_m.empty() && inflight_m.empty();
+
+        no_inflight_requests_o.write(no_inflight);
     }
 
     static uint64_t align_to(uint64_t val, uint64_t align) { return (val / align) * align; }

--- a/rtl/tb/include/hpdcache_test_scoreboard.h
+++ b/rtl/tb/include/hpdcache_test_scoreboard.h
@@ -68,6 +68,8 @@ public:
     sc_in<bool> evt_stall_refill_i;
     sc_in<bool> evt_stall_i;
 
+    sc_out<bool> no_inflight_requests_o;
+
     hpdcache_test_scoreboard(sc_core::sc_module_name nm)
       : sc_module(nm)
       , core_req_i("core_req_i")
@@ -125,6 +127,9 @@ public:
 
         SC_METHOD(perf_events_process);
         sensitive << clk_i.pos();
+
+        SC_METHOD(check_inflight_requests);
+        sensitive << clk_i.neg();
     }
 
     ~hpdcache_test_scoreboard()
@@ -371,6 +376,15 @@ private:
         if (evt_rtab_rollback_i.read()) evt_rtab_rollback++;
         if (evt_stall_refill_i.read()) evt_stall_refill++;
         if (evt_stall_i.read()) evt_stall++;
+    }
+
+    void check_inflight_requests() {
+        const bool no_inflight =
+        inflight_mem_write_m.empty() &&
+        inflight_mem_read_m.empty() &&
+        inflight_m.empty();
+    
+        no_inflight_requests_o.write(no_inflight);        
     }
 
     static uint64_t align_to(uint64_t val, uint64_t align) { return (val / align) * align; }

--- a/rtl/tb/include/hpdcache_test_scoreboard.h
+++ b/rtl/tb/include/hpdcache_test_scoreboard.h
@@ -67,7 +67,6 @@ public:
     sc_in<bool> evt_rtab_rollback_i;
     sc_in<bool> evt_stall_refill_i;
     sc_in<bool> evt_stall_i;
-
     sc_out<bool> no_inflight_requests_o;
 
     hpdcache_test_scoreboard(sc_core::sc_module_name nm)
@@ -379,12 +378,11 @@ private:
     }
 
     void check_inflight_requests() {
-        const bool no_inflight =
-        inflight_mem_write_m.empty() &&
-        inflight_mem_read_m.empty() &&
-        inflight_m.empty();
+      const bool no_inflight = inflight_mem_write_m.empty() &&
+                               inflight_mem_read_m.empty() &&
+                               inflight_m.empty();
     
-        no_inflight_requests_o.write(no_inflight);        
+      no_inflight_requests_o.write(no_inflight);
     }
 
     static uint64_t align_to(uint64_t val, uint64_t align) { return (val / align) * align; }


### PR DESCRIPTION
This PR addresses the existing FIXME in the `hpdcache_test_driver.h` that waits for a fixed number of cycles before finishing the simulation.

Instead of relying on a fixed delay, the testbench now terminates when the scoreboard reports that there are no inflight requests left.

Summary:
- add a no-inflight signal in the scoreboard
- forward the signal through the testbench/agent to the driver
- finish the simulation only after all tracked requests have completed

This makes the simulation termination condition explicit and avoids depending on a hardcoded post-traffic wait.