### PR TITLE
[rtl] Width calculations fixed for size one

### DIFF
--- a/rtl/src/common/hpdcache_data_downsize.sv
+++ b/rtl/src/common/hpdcache_data_downsize.sv
@@ -58,8 +58,8 @@ import hpdcache_pkg::*;
     //  Local definitions
     //  {{{
     localparam int RD_WORDS = WR_WIDTH/RD_WIDTH;
-    localparam int PTR_WIDTH = $clog2(DEPTH);
-    localparam int WORDCNT_WIDTH = $clog2(RD_WORDS);
+    localparam int PTR_WIDTH = hpdcache_vbits(DEPTH);
+    localparam int WORDCNT_WIDTH = hpdcache_vbits(RD_WORDS);
     typedef logic [PTR_WIDTH-1:0]  bufptr_t;
     typedef logic [WORDCNT_WIDTH-1:0]  wordptr_t;
     typedef logic [PTR_WIDTH:0]  occupancy_t;

--- a/rtl/src/common/hpdcache_demux.sv
+++ b/rtl/src/common/hpdcache_demux.sv
@@ -37,8 +37,8 @@ module hpdcache_demux
     parameter  bit          ONE_HOT_SEL = 0,
 
     //  Compute the width of the selection signal
-    localparam int unsigned NOUTPUT_LOG2 = $clog2(NOUTPUT),
-    localparam int unsigned SEL_WIDTH    = ONE_HOT_SEL ? NOUTPUT : NOUTPUT_LOG2,
+    localparam int unsigned NOUTPUT_WIDTH = (NOUTPUT == 1) ? 1 : $clog2(NOUTPUT),
+    localparam int unsigned SEL_WIDTH     = ONE_HOT_SEL ? NOUTPUT : NOUTPUT_WIDTH,
 
     localparam type data_t = logic [DATA_WIDTH-1:0],
     localparam type sel_t  = logic [SEL_WIDTH-1:0]

--- a/rtl/src/common/hpdcache_mux.sv
+++ b/rtl/src/common/hpdcache_mux.sv
@@ -37,8 +37,8 @@ module hpdcache_mux
     parameter  bit          ONE_HOT_SEL = 0,
 
     //  Compute the width of the selection signal
-    localparam int unsigned NINPUT_LOG2 = $clog2(NINPUT),
-    localparam int unsigned SEL_WIDTH   = ONE_HOT_SEL ? NINPUT : NINPUT_LOG2,
+    localparam int unsigned NINPUT_WIDTH = (NINPUT == 1) ? 1 : $clog2(NINPUT),
+    localparam int unsigned SEL_WIDTH    = ONE_HOT_SEL ? NINPUT : NINPUT_WIDTH,
 
     localparam type data_t = logic [DATA_WIDTH-1:0],
     localparam type sel_t  = logic [SEL_WIDTH-1:0]

--- a/rtl/src/hpdcache_ctrl.sv
+++ b/rtl/src/hpdcache_ctrl.sv
@@ -265,8 +265,8 @@ import hpdcache_pkg::*;
 
     //  Definition of types and constants
     //  {{{
-    typedef logic [$clog2(HPDcacheCfg.u.rtabEntries)-1:0] rtab_ptr_t;
-    typedef logic [$clog2(HPDcacheCfg.u.rtabEntries):0]   rtab_cnt_t;
+    typedef logic [hpdcache_vbits(HPDcacheCfg.u.rtabEntries)-1:0] rtab_ptr_t;
+    typedef logic [hpdcache_vbits(HPDcacheCfg.u.rtabEntries):0]   rtab_cnt_t;
 
     //    Extended request type
     typedef struct packed {
@@ -1414,7 +1414,7 @@ import hpdcache_pkg::*;
             scrub_req_valid = 1'b0;
             scrub_req = '0;
             scrub_req.req.op = hpdcache_pkg::HPDCACHE_REQ_LOAD;
-            scrub_req.req.size = hpdcache_req_size_t'($clog2(HPDcacheCfg.accessBytes));
+            scrub_req.req.size = hpdcache_req_size_t'(hpdcache_vbits(HPDcacheCfg.accessBytes));
             scrub_req.req.pma.wr_policy_hint = hpdcache_pkg::HPDCACHE_WR_POLICY_AUTO;
             scrub_req.req.addr_offset[0 +: HPDcacheCfg.clOffsetWidth] =
                     cl_offset[0 +: HPDcacheCfg.clOffsetWidth];

--- a/rtl/src/hpdcache_flush.sv
+++ b/rtl/src/hpdcache_flush.sv
@@ -108,7 +108,7 @@ import hpdcache_pkg::*;
     //  Definition of constants and types
     //  {{{
     localparam int unsigned FlushEntries = HPDcacheCfg.u.flushEntries;
-    localparam int unsigned FlushIndexWidth = (FlushEntries > 1) ? $clog2(FlushEntries) : 1;
+    localparam int unsigned FlushIndexWidth = hpdcache_vbits(FlushEntries);
     // FlushMaxEntries is equal to FlushEntries if it is a power of two
     localparam int unsigned FlushMaxEntries = 2 ** FlushIndexWidth;
 

--- a/rtl/src/hpdcache_memctrl.sv
+++ b/rtl/src/hpdcache_memctrl.sv
@@ -189,20 +189,19 @@ import hpdcache_pkg::*;
     //  {{{
     localparam int unsigned HPDCACHE_DIR_ENTRY_WIDTH = $bits(hpdcache_dir_entry_t);
     localparam int unsigned HPDCACHE_DIR_RAM_WIDTH = HPDCACHE_DIR_ENTRY_WIDTH;
-    localparam int unsigned HPDCACHE_DIR_RAM_ADDR_WIDTH = $clog2(HPDcacheCfg.u.sets);
+    localparam int unsigned HPDCACHE_DIR_RAM_ADDR_WIDTH = hpdcache_vbits(HPDcacheCfg.u.sets);
     localparam int unsigned HPDCACHE_DATA_RAM_ENTR_PER_SET = HPDcacheCfg.u.clWords/
                                                              HPDcacheCfg.u.accessWords;
     localparam int unsigned HPDCACHE_DATA_RAM_DEPTH = HPDcacheCfg.u.sets*
                                                       HPDCACHE_DATA_RAM_ENTR_PER_SET;
-    localparam int unsigned HPDCACHE_DATA_RAM_ADDR_WIDTH = $clog2(HPDCACHE_DATA_RAM_DEPTH);
+    localparam int unsigned HPDCACHE_DATA_RAM_ADDR_WIDTH = hpdcache_vbits(HPDCACHE_DATA_RAM_DEPTH);
     localparam int unsigned HPDCACHE_DATA_REQ_RATIO = HPDcacheCfg.u.accessWords/
                                                       HPDcacheCfg.u.reqWords;
     localparam int unsigned HPDCACHE_DATA_RAM_Y_CUTS = HPDcacheCfg.u.ways/
                                                        HPDcacheCfg.u.dataWaysPerRamWord;
     localparam int unsigned HPDCACHE_DATA_RAM_X_CUTS = HPDcacheCfg.u.accessWords;
 
-    localparam int unsigned RAM_WAY_IDX_BITS = HPDcacheCfg.u.dataWaysPerRamWord > 1 ?
-            $clog2(HPDcacheCfg.u.dataWaysPerRamWord) : 1;
+    localparam int unsigned RAM_WAY_IDX_BITS = hpdcache_vbits(HPDcacheCfg.u.dataWaysPerRamWord);
 
     typedef logic [HPDCACHE_DIR_RAM_ADDR_WIDTH-1:0] hpdcache_dir_addr_t;
 
@@ -244,8 +243,7 @@ import hpdcache_pkg::*;
             input hpdcache_req_size_t size_i,
             input hpdcache_word_t     word_i);
 
-        localparam hpdcache_uint32 OffWidth =
-                HPDcacheCfg.u.accessWords > 1 ? $clog2(HPDcacheCfg.u.accessWords) : 1;
+        localparam hpdcache_uint32 OffWidth = hpdcache_vbits(HPDcacheCfg.u.accessWords);
 
         hpdcache_data_row_enable_t ret;
         hpdcache_uint32 off;
@@ -819,7 +817,7 @@ import hpdcache_pkg::*;
                 data_write        = 1'b1;
                 data_write_enable = 1'b1;
                 data_write_set    = data_refill_set_i;
-                data_write_size   = hpdcache_req_size_t'($clog2(HPDcacheCfg.accessWidth/8));
+                data_write_size   = hpdcache_req_size_t'(hpdcache_vbits(HPDcacheCfg.accessWidth/8));
                 data_write_word   = data_refill_word_i;
                 data_write_data   = data_refill_data_i;
                 data_write_be     = '1;
@@ -849,7 +847,7 @@ import hpdcache_pkg::*;
                 data_write        = 1'b1;
                 data_write_enable = 1'b1;
                 data_write_set    = data_err_set_i;
-                data_write_size   = hpdcache_req_size_t'($clog2(HPDcacheCfg.accessWidth/8));
+                data_write_size   = hpdcache_req_size_t'(hpdcache_vbits(HPDcacheCfg.accessWidth/8));
                 data_write_word   = data_err_word_i;
                 data_write_data   = data_err_wdata_i;
                 data_write_be     = '1;
@@ -881,14 +879,14 @@ import hpdcache_pkg::*;
             data_flush_read_i: begin
                 data_read         = 1'b1;
                 data_read_set     = data_flush_read_set_i;
-                data_read_size    = hpdcache_req_size_t'($clog2(HPDcacheCfg.accessWidth/8));
+                data_read_size    = hpdcache_req_size_t'(hpdcache_vbits(HPDcacheCfg.accessWidth/8));
                 data_read_word    = data_flush_read_word_i;
             end
 
             data_err_read_i: begin
                 data_read         = 1'b1;
                 data_read_set     = data_err_set_i;
-                data_read_size    = hpdcache_req_size_t'($clog2(HPDcacheCfg.accessWidth/8));
+                data_read_size    = hpdcache_req_size_t'(hpdcache_vbits(HPDcacheCfg.accessWidth/8));
                 data_read_word    = data_err_word_i;
             end
 
@@ -986,8 +984,7 @@ import hpdcache_pkg::*;
     end
 
     //  Mux the data according to the access word
-    localparam int unsigned DATA_WORD_IDX_WIDTH =
-            HPDCACHE_DATA_REQ_RATIO > 1 ?  $clog2(HPDCACHE_DATA_REQ_RATIO) : 1;
+    localparam int unsigned DATA_WORD_IDX_WIDTH = hpdcache_vbits(HPDCACHE_DATA_REQ_RATIO);
     typedef logic [DATA_WORD_IDX_WIDTH-1:0] data_req_word_t;
 
     if (HPDCACHE_DATA_REQ_RATIO > 1) begin : gen_req_width_lt_ram_width

--- a/rtl/src/hpdcache_pkg.sv
+++ b/rtl/src/hpdcache_pkg.sv
@@ -97,6 +97,10 @@ package hpdcache_pkg;
         return (x < y) ? x : y;
     endfunction
 
+    function automatic integer hpdcache_vbits(integer value);
+        return (value == 1) ? 1 : $clog2(value);
+    endfunction
+
     function automatic logic is_load(input hpdcache_req_op_t op);
         case (op)
             HPDCACHE_REQ_LOAD: return 1'b1;
@@ -485,26 +489,26 @@ package hpdcache_pkg;
         ret.u = p;
 
         ret.clWidth = p.clWords * p.wordWidth;
-        ret.clOffsetWidth = $clog2(ret.clWidth / 8);
-        ret.clWordIdxWidth = $clog2(p.clWords);
-        ret.wordByteIdxWidth = $clog2(p.wordWidth / 8);
-        ret.wayIndexWidth = (p.ways > 1) ? $clog2(p.ways) : 1;
-        ret.setWidth = $clog2(p.sets);
+        ret.clOffsetWidth = hpdcache_vbits(ret.clWidth / 8);
+        ret.clWordIdxWidth = hpdcache_vbits(p.clWords);
+        ret.wordByteIdxWidth = hpdcache_vbits(p.wordWidth / 8);
+        ret.wayIndexWidth = hpdcache_vbits(p.ways);
+        ret.setWidth = hpdcache_vbits(p.sets);
         ret.nlineWidth = p.paWidth - ret.clOffsetWidth;
         ret.tagWidth = ret.nlineWidth - ret.setWidth;
-        ret.reqWordIdxWidth = $clog2(p.reqWords);
+        ret.reqWordIdxWidth = hpdcache_vbits(p.reqWords);
         ret.reqOffsetWidth = p.paWidth - ret.tagWidth;
         ret.reqDataWidth = p.reqWords * p.wordWidth;
         ret.reqDataBytes = ret.reqDataWidth/8;
 
-        ret.mshrSetWidth = (p.mshrSets > 1) ? $clog2(p.mshrSets) : 1;
-        ret.mshrWayWidth = (p.mshrWays > 1) ? $clog2(p.mshrWays) : 1;
+        ret.mshrSetWidth = hpdcache_vbits(p.mshrSets);
+        ret.mshrWayWidth = hpdcache_vbits(p.mshrWays);
 
-        ret.cbufEntryWidth = (p.cbufEntries > 1) ? $clog2(p.cbufEntries) : 1;
+        ret.cbufEntryWidth = hpdcache_vbits(p.cbufEntries);
 
         ret.wbufDataWidth = ret.reqDataWidth*p.wbufWords;
-        ret.wbufDirPtrWidth = $clog2(p.wbufDirEntries);
-        ret.wbufDataPtrWidth = $clog2(p.wbufDataEntries);
+        ret.wbufDirPtrWidth = hpdcache_vbits(p.wbufDirEntries);
+        ret.wbufDataPtrWidth = hpdcache_vbits(p.wbufDataEntries);
 
         ret.accessWidth = p.accessWords * p.wordWidth;
         ret.accessBytes = ret.accessWidth/8;

--- a/rtl/src/hpdcache_uncached.sv
+++ b/rtl/src/hpdcache_uncached.sv
@@ -134,7 +134,7 @@ import hpdcache_pkg::*;
 //  Definition of constants and types
 //  {{{
     localparam hpdcache_uint MEM_REQ_RATIO = HPDcacheCfg.u.memDataWidth/HPDcacheCfg.reqDataWidth;
-    localparam hpdcache_uint MEM_REQ_WORD_INDEX_WIDTH = $clog2(MEM_REQ_RATIO);
+    localparam hpdcache_uint MEM_REQ_WORD_INDEX_WIDTH = hpdcache_vbits(MEM_REQ_RATIO);
 
     typedef enum {
         UC_IDLE,
@@ -556,7 +556,7 @@ import hpdcache_pkg::*;
 //  AMO unit
 //  {{{
     if (HPDcacheCfg.reqDataWidth > 64) begin : gen_amo_data_width_gt_64
-        localparam hpdcache_uint AMO_WORD_INDEX_WIDTH = $clog2(HPDcacheCfg.reqDataWidth/64);
+        localparam hpdcache_uint AMO_WORD_INDEX_WIDTH = hpdcache_vbits(HPDcacheCfg.reqDataWidth/64);
         hpdcache_mux #(
             .NINPUT         (HPDcacheCfg.reqDataWidth/64),
             .DATA_WIDTH     (64),

--- a/rtl/src/hpdcache_victim_plru.sv
+++ b/rtl/src/hpdcache_victim_plru.sv
@@ -31,7 +31,7 @@ import hpdcache_pkg::*;
 #(
     parameter hpdcache_cfg_t HPDcacheCfg = '0,
 
-    localparam type set_t        = logic [$clog2(HPDcacheCfg.u.sets)-1:0],
+    localparam type set_t        = logic [hpdcache_vbits(HPDcacheCfg.u.sets)-1:0],
     localparam type way_vector_t = logic [HPDcacheCfg.u.ways-1:0]
 )
     //  }}}

--- a/rtl/src/hpdcache_victim_random.sv
+++ b/rtl/src/hpdcache_victim_random.sv
@@ -31,7 +31,7 @@ import hpdcache_pkg::*;
 #(
     parameter hpdcache_cfg_t HPDcacheCfg = '0,
 
-    localparam type set_t        = logic [$clog2(HPDcacheCfg.u.sets)-1:0],
+    localparam type set_t        = logic [hpdcache_vbits(HPDcacheCfg.u.sets)-1:0],
     localparam type way_vector_t = logic [HPDcacheCfg.u.ways-1:0]
 )
     //  }}}

--- a/rtl/src/hpdcache_wbuf.sv
+++ b/rtl/src/hpdcache_wbuf.sv
@@ -108,14 +108,14 @@ import hpdcache_pkg::*;
     localparam int unsigned WBUF_DIR_NENTRIES = HPDcacheCfg.u.wbufDirEntries;
     localparam int unsigned WBUF_DATA_NENTRIES = HPDcacheCfg.u.wbufDataEntries;
     localparam int unsigned WBUF_DATA_NWORDS = HPDcacheCfg.u.wbufWords;
-    localparam int unsigned WBUF_OFFSET_WIDTH = $clog2((WBUF_WORD_WIDTH/8)*WBUF_DATA_NWORDS);
+    localparam int unsigned WBUF_OFFSET_WIDTH = hpdcache_vbits((WBUF_WORD_WIDTH/8)*WBUF_DATA_NWORDS);
     localparam int unsigned WBUF_TAG_WIDTH = HPDcacheCfg.u.paWidth - WBUF_OFFSET_WIDTH;
-    localparam int unsigned WBUF_WORD_OFFSET = $clog2(WBUF_WORD_WIDTH/8);
+    localparam int unsigned WBUF_WORD_OFFSET = hpdcache_vbits(WBUF_WORD_WIDTH/8);
     localparam int          WBUF_SEND_FIFO_DEPTH = WBUF_DATA_NENTRIES;
     localparam int unsigned WBUF_READ_MATCH_WIDTH = HPDcacheCfg.nlineWidth;
     localparam int unsigned WBUF_MEM_DATA_RATIO = HPDcacheCfg.u.memDataWidth/
                                                   HPDcacheCfg.wbufDataWidth;
-    localparam int unsigned WBUF_MEM_DATA_WORD_INDEX_WIDTH = $clog2(WBUF_MEM_DATA_RATIO);
+    localparam int unsigned WBUF_MEM_DATA_WORD_INDEX_WIDTH = hpdcache_vbits(WBUF_MEM_DATA_RATIO);
 
     typedef wbuf_data_t [WBUF_DATA_NWORDS-1:0] wbuf_data_buf_t;
     typedef wbuf_be_t [WBUF_DATA_NWORDS-1:0] wbuf_be_buf_t;

--- a/rtl/src/utils/hpdcache_to_l15.sv
+++ b/rtl/src/utils/hpdcache_to_l15.sv
@@ -27,11 +27,11 @@ module hpdcache_to_l15 import hpdcache_pkg::*, l15_pkg::*;
 //  Parameters
 //  {{{
 #(
-    parameter hpdcache_uint          NumPorts        = 4,
-    parameter [$clog2(NumPorts)-1:0] IcachePort      = 0,
-    parameter [$clog2(NumPorts)-1:0] DcacheReadPort  = 1,
-    parameter [$clog2(NumPorts)-1:0] DcacheWritePort = 2,
-    parameter [$clog2(NumPorts)-1:0] DcacheAmoPort   = 3,
+    parameter hpdcache_uint                  NumPorts        = 4,
+    parameter [hpdcache_vbits(NumPorts)-1:0] IcachePort      = 0,
+    parameter [hpdcache_vbits(NumPorts)-1:0] DcacheReadPort  = 1,
+    parameter [hpdcache_vbits(NumPorts)-1:0] DcacheWritePort = 2,
+    parameter [hpdcache_vbits(NumPorts)-1:0] DcacheAmoPort   = 3,
 
     parameter bit              SwapEndianness = 1,
     parameter hpdcache_uint    HPDcacheMemDataWidth = 128,


### PR DESCRIPTION
This was a problem throughout the code so I made a function called hpdcache_vbits so we don't have to replicate this logic throughout the design.