### PR TITLE
Treat PMA I/O regions as uncacheable 

### DIFF
--- a/rtl/src/hpdcache_ctrl.sv
+++ b/rtl/src/hpdcache_ctrl.sv
@@ -509,7 +509,7 @@ import hpdcache_pkg::*;
     end
 
     //     Decode operation in stage 0
-    assign st0_req_is_uncacheable  =     st0_req.req.pma.uncacheable;
+    assign st0_req_is_uncacheable  =     st0_req.req.pma.uncacheable | st0_req.req.pma.io;
     assign st0_req_is_load         =         is_load(st0_req.req.op) & ~st0_req.err_scrubbing;
     assign st0_req_is_scrub        =         is_load(st0_req.req.op) &  st0_req.err_scrubbing;
     assign st0_req_is_store        =        is_store(st0_req.req.op);
@@ -559,7 +559,7 @@ import hpdcache_pkg::*;
     //         previous cycle (stage 0). Useful in case of TLB miss for example
     assign st1_req_abort           = core_req_abort_i & ~st1_req.req.phys_indexed;
 
-    assign st1_req_is_uncacheable  = ~cfg_enable_i | st1_req.req.pma.uncacheable;
+    assign st1_req_is_uncacheable  = ~cfg_enable_i | st1_req.req.pma.uncacheable | st1_req.req.pma.io;
     assign st1_req_is_load         =         is_load(st1_req.req.op) & ~st1_req.err_scrubbing;
     assign st1_req_is_store        =        is_store(st1_req.req.op);
     assign st1_req_is_amo          =          is_amo(st1_req.req.op);

--- a/rtl/src/hpdcache_ctrl.sv
+++ b/rtl/src/hpdcache_ctrl.sv
@@ -559,7 +559,8 @@ import hpdcache_pkg::*;
     //         previous cycle (stage 0). Useful in case of TLB miss for example
     assign st1_req_abort           = core_req_abort_i & ~st1_req.req.phys_indexed;
 
-    assign st1_req_is_uncacheable  = ~cfg_enable_i | st1_req.req.pma.uncacheable | st1_req.req.pma.io;
+    assign st1_req_is_uncacheable  = ~cfg_enable_i | st1_req.req.pma.uncacheable 
+                                                    | st1_req.req.pma.io;
     assign st1_req_is_load         =         is_load(st1_req.req.op) & ~st1_req.err_scrubbing;
     assign st1_req_is_store        =        is_store(st1_req.req.op);
     assign st1_req_is_amo          =          is_amo(st1_req.req.op);


### PR DESCRIPTION
Hi,

I am currently working on the Svpbmt extension in the CVA6 core. While looking into the CVA6 HPDcache adapter, I noticed that the adapter currently always drives the `io` field of the request PMA to 0.
And HPDcache itself already defines an `io` field in `hpdcache_pma_t`, and the current cache controller only checks pma.uncacheable when deriving the uncacheable request path. 

However, this means that, if an integration provides a request with `pma.io = 1` and `pma.uncacheable = 0`, the request may still be routed through the cacheable path.

This patch treats PMA I/O regions as uncacheable for cache protocol routing by including `pma.io` in the uncacheable decode logic for both stage 0 and stage 1.

--
I am not sure if there is an existing plan for the 'io' field, since it is currently described as future work. However, my understanding is that an I/O region should at least be treated as uncacheable by the cache system.

Thanks :) 