### PR TITLE
memctrl: Disable directory chip-select when reset is active

### DIFF
--- a/rtl/src/hpdcache_memctrl.sv
+++ b/rtl/src/hpdcache_memctrl.sv
@@ -369,7 +369,9 @@ import hpdcache_pkg::*;
             1'b0: begin
                 init_d      = (hpdcache_uint'(init_set_q) == (HPDcacheCfg.u.sets - 1));
                 init_set_d  = init_set_q + 1;
-                init_dir_cs = '1;
+                if (rst_ni) begin
+                    init_dir_cs = '1;
+                end
             end
 
             1'b1: begin


### PR DESCRIPTION
Hi @cfuguet,

As discussed, this is a small patch to decrease the power consumption of the directory SRAMs, when the reset is active.

Thanks,
Davy