### PR TITLE
Add an assertion to check that the refillFifoDepth parameter has the minimum value required

### DIFF
--- a/.github/scripts/env_syn.sh
+++ b/.github/scripts/env_syn.sh
@@ -18,8 +18,8 @@ export PARALLEL_JOBS=7
 mkdir -p ${ARCHIVE_DIR} ${BUILD_DIR} ;
 
 #  OSS-CAD-Suite env variables
-export OSS_CAD_SUITE_URL=https://github.com/YosysHQ/oss-cad-suite-build/releases/download/2025-06-02/oss-cad-suite-linux-x64-20250602.tgz
-export OSS_CAD_SUITE_VER=2025-06-02
+export OSS_CAD_SUITE_VER=2026-05-29
+export OSS_CAD_SUITE_URL=https://github.com/YosysHQ/oss-cad-suite-build/releases/download/${OSS_CAD_SUITE_VER}/oss-cad-suite-linux-x64-${OSS_CAD_SUITE_VER//-/}.tgz
 export OSS_CAD_SUITE_ROOT=${BUILD_DIR}/oss-cad-suite
 
 if [[ -e ${OSS_CAD_SUITE_ROOT}/environment ]] ; then

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ To do that, we invite you to follow the following steps:
    Please follow the corresponding instructions before creating a pull-request
 2. In some cases, it may be interesting to open an issue with the "question" tag to ask if someone is already working on the feature you would like to propose, or if the community would be interested in such feature
 3. If you modify the RTL or the testbench's C++ code, before creating the pull-request, you should run the provided smoke tests.
-   The provided ``smoke_tests.sh`` script does some code formatting checks (RTL and C++), and also runs some tests in the C++ testbench with different hardware configurations of the HPDcache.
+   The provided ``smoke_tests.sh`` script does some code formatting checks (RTL and C++), and also runs some tests in the C++ testbench with different hardware configurations of the HPDcache. This requires some tools and libraries to be installed locally. See section [How to run tests locally](#how-to-run-tests-locally) for instructions to install them.
 ```bash
 bash ./rtl/tb/scripts/smoke_tests.sh
 ```
@@ -42,6 +42,22 @@ You can rerun the failing test locally to debug the issue.
 
 You can go into the ``rtl/tb`` directory if you want to run other tests or if you want to debug any issues found during the execution of smoke tests.
 Please read the testbench's [README.md](rtl/tb/README.md) to see how to do that.
+
+You will need to install some tools and libraries locally in order to be able to run the testbench (namely Verilator and SystemC).
+You can use the following procedure to do so:
+```bash
+source .github/scripts/env.sh
+bash .github/scripts/install_systemc.sh
+bash .github/scripts/install_verilator.sh
+```
+
+These tools have some pre-requisites, that you can install using the following if your machine is running on Ubuntu:
+```bash
+bash .github/scripts/install_deps_ubuntu.sh
+```
+
+Otherwise, for convenience, we provide a [default.nix](https://github.com/openhwgroup/cv-hpdcache/blob/master/default.nix) file that you use with the [Nix](https://nixos.org/) package manager to install all pre-requisites within a nix-shell.
+Once in the nix-shell, you can run the scripts in .github/scripts as described above to install the required tools and libraries.
 
 ## Code Conventions
 

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,60 @@
+let
+  nixpkgs = fetchTarball "https://github.com/NixOS/nixpkgs/tarball/nixos-24.05";
+  pkgs = import nixpkgs { config = {}; overlays = []; };
+
+in pkgs.mkShell {
+  packages = with pkgs; [
+    gcc13
+    gcc13Stdenv
+    wget
+    less
+    cmake
+    autoconf
+    automake
+    curl
+    git
+    isl
+    libmpc
+    mpfr
+    gmp
+    gawk
+    gnupg
+    bison
+    flex
+    texinfo
+    gperf
+    libtool
+    bc
+    zlib
+    bash
+    ccache
+    gnumake
+    help2man
+    openssh
+    perl
+    util-linux
+    vim
+    zlib
+    locale
+    (python3.withPackages (python-pkgs: [
+      python-pkgs.hjson
+      python-pkgs.mako
+      python-pkgs.sphinx
+      python-pkgs.sphinxcontrib-log-cabinet
+      python-pkgs.sphinx_rtd_theme
+      python-pkgs.recommonmark
+      python-pkgs.pandas
+    ]))
+  ];
+
+  hardeningDisable = [ "all" ];
+
+  stdenv = pkgs.gcc13Stdenv;
+
+  shellHook = ''
+    export LOCALE_ARCHIVE=/usr/lib/locale/locale-archive ;
+    export HPDCACHE_DIR=${toString ./.} ;
+    export RISCV=${toString ./.}/tools/riscv ;
+    source .github/scripts/env.sh ;
+  '';
+}

--- a/rtl/src/common/hpdcache_data_downsize.sv
+++ b/rtl/src/common/hpdcache_data_downsize.sv
@@ -31,6 +31,14 @@ import hpdcache_pkg::*;
 #(
     parameter int WR_WIDTH = 0,
     parameter int RD_WIDTH = 0,
+
+    /*  The actual number of words in the downsizer is computed as
+     *  FIFO_WORDS = DEPTH * (WR_WIDTH/RD_WIDTH)
+     *
+     *  The size of a word in this component is defined as the number of bytes
+     *  produced by the writer at each write access
+     *  WORD_WIDTH = RD_WIDTH
+     */
     parameter int DEPTH    = 0,
 
     localparam type wdata_t = logic [WR_WIDTH-1:0],
@@ -189,3 +197,4 @@ import hpdcache_pkg::*;
 //  }}}
 endmodule
 //  }}}
+// vim: ts=4 : sts=4 : sw=4 : et : tw=100 : spell : spelllang=en : fdm=marker

--- a/rtl/src/common/hpdcache_data_upsize.sv
+++ b/rtl/src/common/hpdcache_data_upsize.sv
@@ -31,6 +31,14 @@ import hpdcache_pkg::*;
 #(
     parameter int WR_WIDTH = 0,
     parameter int RD_WIDTH = 0,
+
+    /*  The actual number of words in the upsizer is computed as
+     *  FIFO_WORDS = DEPTH * (RD_WIDTH/WR_WIDTH)
+     *
+     *  The size of a word in this component is defined as the number of bytes
+     *  consumed by the reader at each read access
+     *  WORD_WIDTH = WR_WIDTH
+     */
     parameter int DEPTH    = 0,
 
     localparam type wdata_t = logic [WR_WIDTH-1:0],

--- a/rtl/src/hpdcache_miss_handler.sv
+++ b/rtl/src/hpdcache_miss_handler.sv
@@ -151,7 +151,6 @@ import hpdcache_pkg::*;
                                                 HPDcacheCfg.u.reqWords;
     localparam hpdcache_uint REFILL_LAST_CHUNK_WORD = HPDcacheCfg.u.clWords -
                                                       HPDcacheCfg.u.accessWords;
-
     typedef enum logic {
         MISS_REQ_IDLE = 1'b0,
         MISS_REQ_SEND = 1'b1
@@ -886,8 +885,19 @@ import hpdcache_pkg::*;
     //  Assertions
     //  {{{
 `ifndef HPDCACHE_ASSERT_OFF
+    localparam hpdcache_uint REFILL_MEM_WORDS =
+        HPDcacheCfg.u.memDataWidth/HPDcacheCfg.u.wordWidth;
+    localparam hpdcache_uint REFILL_FIFO_WORDS_PER_ENTRY =
+        hpdcache_max(REFILL_MEM_WORDS, HPDcacheCfg.u.accessWords);
+    localparam hpdcache_uint REFILL_FIFO_WORDS =
+        REFILL_FIFO_WORDS_PER_ENTRY*HPDcacheCfg.u.refillFifoDepth;
+
+    if (REFILL_FIFO_WORDS < HPDcacheCfg.u.clWords) begin : gen_refill_depth_assertion
+        $fatal(1, "the refill fifo shall be able to buffer at least a full cacheline");
+    end
 `endif
     //  }}}
 
 endmodule
 //  }}}
+// vim: ts=4 : sts=4 : sw=4 : et : tw=100 : spell : spelllang=en : fdm=marker

--- a/rtl/tb/README.md
+++ b/rtl/tb/README.md
@@ -23,6 +23,9 @@ This testbench requires the following tools and libraries pre-installed:
 
 Please follow the corresponding installation instructions for those packages to
 install them in your system prior to the execution of this testbench.
+Alternatively, you can also follow the instructions in the
+[CONTRIBUTING.md](https://github.com/openhwgroup/cv-hpdcache/blob/master/CONTRIBUTING.md)
+file to install these tools and libraries with the provided scripts.
 
 You need to set the following environment variables (bash: `$ export`, csh: `$ setenv`):
 
@@ -30,6 +33,12 @@ You need to set the following environment variables (bash: `$ export`, csh: `$ s
   (e.g. `$ export SYSTEMC_LIBDIR=<systemc-install-dir>/lib-linux64`)
 - Add the bin/ subdirectory of the Verilator installation into your PATH
   (e.g. `$ export PATH=<verilator-install-dir>/bin:${PATH}`)
+
+If you installed the tools using the instructions in
+[CONTRIBUTING.md](https://github.com/openhwgroup/cv-hpdcache/blob/master/CONTRIBUTING.md),
+then you can set above environment variables by sourcing the
+[.github/scripts/env.sh](https://github.com/openhwgroup/cv-hpdcache/blob/master/.github/scripts/env.sh)
+file.
 
 In addition to above packages, the C++ code of this testbench is and shall be
 formatted using the clang-format tool. The .clang-format file contains the


### PR DESCRIPTION
The miss handler in the HPDcache implements a FIFO buffer for memory read miss responses. There is a minimum depth that must be observed for the cache to work correctly. This minimum depth depends on other parameters.

This PR adds an assertion that checks that this parameter is correctly assigned.