### PR TITLE
fix: add missing assignment to the dir update fetch bit

### DIFF
--- a/rtl/src/hpdcache_ctrl_pe.sv
+++ b/rtl/src/hpdcache_ctrl_pe.sv
@@ -541,11 +541,12 @@ import hpdcache_pkg::*;
                                     uc_req_valid_o = 1'b1;
                                     st1_rtab_commit_o = st1_req_rtab_i;
                                     evt_uncached_req_o = 1'b1;
-                                    // Invalidate cache
+                                    // invalidate the cacheline
                                     st2_dir_updt_o = 1'b1;
                                     st2_dir_updt_valid_o = 1'b0;
                                     st2_dir_updt_wback_o = 1'b0;
                                     st2_dir_updt_dirty_o = 1'b0;
+                                    st2_dir_updt_fetch_o = 1'b0;
                                 end
                             end
                         end


### PR DESCRIPTION
The st2_dir_updt_fetch bit was not correctly reset to 0 when invalidating a cacheline because of a uncacheable access to a cacheline present in the cache.

In this case, that cacheline needs to be invalidated by setting its valid bit in the directory to 0, but also all other state bits (fetch, dirty, wb) shall be reset.