### PR TITLE
Ensure sequential consistency for CMOs through the Replay Table

### DIFF
--- a/rtl/src/hpdcache.sv
+++ b/rtl/src/hpdcache.sv
@@ -275,7 +275,6 @@ import hpdcache_pkg::*;
     hpdcache_req_addr_t    cmo_req_addr;
     hpdcache_req_sid_t     cmo_req_sid;
     hpdcache_req_tid_t     cmo_req_tid;
-    hpdcache_req_data_t    cmo_req_wdata;
     logic                  cmo_req_need_rsp;
     logic                  cmo_dirty_set_en;
     hpdcache_set_t         cmo_dirty_min_set;
@@ -285,12 +284,6 @@ import hpdcache_pkg::*;
     hpdcache_set_t         cmo_valid_max_set;
     logic                  cmo_flush_all;
     logic                  cmo_inval_all;
-    logic                  cmo_dir_check_nline;
-    hpdcache_set_t         cmo_dir_check_nline_set;
-    hpdcache_tag_t         cmo_dir_check_nline_tag;
-    hpdcache_way_vector_t  cmo_dir_check_nline_hit_way;
-    logic                  cmo_dir_check_nline_wback;
-    logic                  cmo_dir_check_nline_dirty;
     logic                  cmo_dir_check_entry;
     hpdcache_set_t         cmo_dir_check_entry_set;
     hpdcache_way_vector_t  cmo_dir_check_entry_way;
@@ -490,8 +483,6 @@ import hpdcache_pkg::*;
 
         .wbuf_flush_i,
 
-        .cachedir_hit_o                     (/* unused */),
-
         .st0_mshr_check_o                   (miss_mshr_check),
         .st0_mshr_check_offset_o            (miss_mshr_check_offset),
         .st1_mshr_check_nline_o             (miss_mshr_check_nline),
@@ -599,7 +590,6 @@ import hpdcache_pkg::*;
         .cmo_req_valid_o                    (cmo_req_valid),
         .cmo_req_op_o                       (cmo_req_op),
         .cmo_req_addr_o                     (cmo_req_addr),
-        .cmo_req_wdata_o                    (cmo_req_wdata),
         .cmo_req_sid_o                      (cmo_req_sid),
         .cmo_req_tid_o                      (cmo_req_tid),
         .cmo_req_need_rsp_o                 (cmo_req_need_rsp),
@@ -611,12 +601,6 @@ import hpdcache_pkg::*;
         .cmo_valid_max_set_o                (cmo_valid_max_set),
         .cmo_flush_all_i                    (cmo_flush_all),
         .cmo_inval_all_i                    (cmo_inval_all),
-        .cmo_dir_check_nline_i              (cmo_dir_check_nline),
-        .cmo_dir_check_nline_set_i          (cmo_dir_check_nline_set),
-        .cmo_dir_check_nline_tag_i          (cmo_dir_check_nline_tag),
-        .cmo_dir_check_nline_hit_way_o      (cmo_dir_check_nline_hit_way),
-        .cmo_dir_check_nline_wback_o        (cmo_dir_check_nline_wback),
-        .cmo_dir_check_nline_dirty_o        (cmo_dir_check_nline_dirty),
         .cmo_dir_check_entry_i              (cmo_dir_check_entry),
         .cmo_dir_check_entry_set_i          (cmo_dir_check_entry_set),
         .cmo_dir_check_entry_way_i          (cmo_dir_check_entry_way),
@@ -940,7 +924,6 @@ import hpdcache_pkg::*;
         .req_ready_o                   (cmo_ready),
         .req_op_i                      (cmo_req_op),
         .req_addr_i                    (cmo_req_addr),
-        .req_wdata_i                   (cmo_req_wdata),
         .req_sid_i                     (cmo_req_sid),
         .req_tid_i                     (cmo_req_tid),
         .req_need_rsp_i                (cmo_req_need_rsp),
@@ -958,12 +941,6 @@ import hpdcache_pkg::*;
         .core_rsp_valid_o              (cmo_core_rsp_valid),
         .core_rsp_o                    (cmo_core_rsp),
 
-        .dir_check_nline_o             (cmo_dir_check_nline),
-        .dir_check_nline_set_o         (cmo_dir_check_nline_set),
-        .dir_check_nline_tag_o         (cmo_dir_check_nline_tag),
-        .dir_check_nline_hit_way_i     (cmo_dir_check_nline_hit_way),
-        .dir_check_nline_wback_i       (cmo_dir_check_nline_wback),
-        .dir_check_nline_dirty_i       (cmo_dir_check_nline_dirty),
 
         .dir_check_entry_o             (cmo_dir_check_entry),
         .dir_check_entry_set_o         (cmo_dir_check_entry_set),

--- a/rtl/src/hpdcache.sv
+++ b/rtl/src/hpdcache.sv
@@ -254,7 +254,6 @@ import hpdcache_pkg::*;
     logic                  uc_req_need_rsp;
     hpdcache_way_vector_t  uc_req_dir_hit_way;
     hpdcache_req_data_t    uc_req_old_data;
-    logic                  uc_wbuf_flush_all;
     logic                  uc_data_amo_write;
     logic                  uc_data_amo_write_enable;
     hpdcache_set_t         uc_data_amo_write_set;
@@ -284,7 +283,6 @@ import hpdcache_pkg::*;
     logic                  cmo_valid_set_en;
     hpdcache_set_t         cmo_valid_min_set;
     hpdcache_set_t         cmo_valid_max_set;
-    logic                  cmo_wbuf_flush_all;
     logic                  cmo_flush_all;
     logic                  cmo_inval_all;
     logic                  cmo_dir_check_nline;
@@ -308,7 +306,6 @@ import hpdcache_pkg::*;
     logic                  cmo_dir_updt_dirty;
     logic                  cmo_dir_updt_fetch;
     hpdcache_tag_t         cmo_dir_updt_tag;
-    logic                  cmo_wait;
     logic                  cmo_flush_alloc;
     hpdcache_nline_t       cmo_flush_alloc_nline;
     hpdcache_way_vector_t  cmo_flush_alloc_way;
@@ -586,7 +583,6 @@ import hpdcache_pkg::*;
         .uc_req_need_rsp_o                  (uc_req_need_rsp),
         .uc_req_dir_hit_way_o               (uc_req_dir_hit_way),
         .uc_req_old_data_o                  (uc_req_old_data),
-        .uc_wbuf_flush_all_i                (uc_wbuf_flush_all),
         .uc_data_amo_write_i                (uc_data_amo_write),
         .uc_data_amo_write_enable_i         (uc_data_amo_write_enable),
         .uc_data_amo_write_set_i            (uc_data_amo_write_set),
@@ -600,7 +596,6 @@ import hpdcache_pkg::*;
         .uc_core_rsp_i                      (uc_core_rsp),
 
         .cmo_busy_i                         (~cmo_ready),
-        .cmo_wait_i                         (cmo_wait),
         .cmo_req_valid_o                    (cmo_req_valid),
         .cmo_req_op_o                       (cmo_req_op),
         .cmo_req_addr_o                     (cmo_req_addr),
@@ -614,7 +609,6 @@ import hpdcache_pkg::*;
         .cmo_valid_set_en_o                 (cmo_valid_set_en),
         .cmo_valid_min_set_o                (cmo_valid_min_set),
         .cmo_valid_max_set_o                (cmo_valid_max_set),
-        .cmo_wbuf_flush_all_i               (cmo_wbuf_flush_all),
         .cmo_flush_all_i                    (cmo_flush_all),
         .cmo_inval_all_i                    (cmo_inval_all),
         .cmo_dir_check_nline_i              (cmo_dir_check_nline),
@@ -878,8 +872,6 @@ import hpdcache_pkg::*;
         .req_hit_way_i                 (uc_req_dir_hit_way),
         .req_old_data_i                (uc_req_old_data),
 
-        .wbuf_flush_all_o              (uc_wbuf_flush_all),
-
         .data_amo_write_o              (uc_data_amo_write),
         .data_amo_write_enable_o       (uc_data_amo_write_enable),
         .data_amo_write_set_o          (uc_data_amo_write_set),
@@ -944,11 +936,6 @@ import hpdcache_pkg::*;
         .clk_i,
         .rst_ni,
 
-        .wbuf_empty_i                  (wbuf_empty_o),
-        .mshr_empty_i                  (miss_mshr_empty),
-        .rtab_empty_i                  (rtab_empty),
-        .ctrl_empty_i                  (ctrl_empty),
-
         .req_valid_i                   (cmo_req_valid),
         .req_ready_o                   (cmo_ready),
         .req_op_i                      (cmo_req_op),
@@ -957,7 +944,6 @@ import hpdcache_pkg::*;
         .req_sid_i                     (cmo_req_sid),
         .req_tid_i                     (cmo_req_tid),
         .req_need_rsp_i                (cmo_req_need_rsp),
-        .req_wait_o                    (cmo_wait),
 
         .dirty_set_en_i                (cmo_dirty_set_en),
         .dirty_min_set_i               (cmo_dirty_min_set),
@@ -971,8 +957,6 @@ import hpdcache_pkg::*;
         .core_rsp_ready_i              (cmo_core_rsp_ready),
         .core_rsp_valid_o              (cmo_core_rsp_valid),
         .core_rsp_o                    (cmo_core_rsp),
-
-        .wbuf_flush_all_o              (cmo_wbuf_flush_all),
 
         .dir_check_nline_o             (cmo_dir_check_nline),
         .dir_check_nline_set_o         (cmo_dir_check_nline_set),

--- a/rtl/src/hpdcache_cmo.sv
+++ b/rtl/src/hpdcache_cmo.sv
@@ -44,7 +44,6 @@ import hpdcache_pkg::*;
     output logic                  req_ready_o,
     input  hpdcache_cmoh_op_t     req_op_i,
     input  hpdcache_req_addr_t    req_addr_i,
-    input  hpdcache_req_data_t    req_wdata_i/*unused*/,
     input  hpdcache_req_sid_t     req_sid_i,
     input  hpdcache_req_tid_t     req_tid_i,
     input  logic                  req_need_rsp_i,
@@ -71,13 +70,6 @@ import hpdcache_pkg::*;
 
     //  Cache Directory Interface
     //  {{{
-    output logic                  dir_check_nline_o,
-    output hpdcache_set_t         dir_check_nline_set_o,
-    output hpdcache_tag_t         dir_check_nline_tag_o,
-    input  hpdcache_way_vector_t  dir_check_nline_hit_way_i,
-    input  logic                  dir_check_nline_wback_i,
-    input  logic                  dir_check_nline_dirty_i,
-
     output logic                  dir_check_entry_o,
     output hpdcache_set_t         dir_check_entry_set_o,
     output hpdcache_way_vector_t  dir_check_entry_way_o,
@@ -111,13 +103,10 @@ import hpdcache_pkg::*;
 //  {{{
     typedef enum {
         CMOH_IDLE = 0,
-        CMOH_INVAL_CHECK_NLINE,
         CMOH_INVAL_SET,
         CMOH_FLUSH_ALL_FIRST,
         CMOH_FLUSH_ALL_NEXT,
-        CMOH_FLUSH_ALL_LAST,
-        CMOH_FLUSH_NLINE_FIRST,
-        CMOH_FLUSH_NLINE_NEXT
+        CMOH_FLUSH_ALL_LAST
     } hpdcache_cmoh_fsm_t;
 //  }}}
 
@@ -134,10 +123,6 @@ import hpdcache_pkg::*;
     hpdcache_way_vector_t cmoh_flush_req_way_q, cmoh_flush_req_way_d;
     logic                 cmoh_flush_req_inval_q, cmoh_flush_req_inval_d;
 
-    logic                 cmoh_dir_check_nline_hit;
-    hpdcache_nline_t      cmoh_nline;
-    hpdcache_set_t        cmoh_set;
-    hpdcache_tag_t        cmoh_tag;
     logic                 cmoh_flush_req_w;
     logic                 cmoh_flush_req_wok;
     hpdcache_set_t        cmoh_flush_req_set;
@@ -174,12 +159,6 @@ import hpdcache_pkg::*;
 
 //  CMO request handler FSM
 //  {{{
-    assign cmoh_nline = cmoh_addr_q[HPDcacheCfg.clOffsetWidth +: HPDcacheCfg.nlineWidth];
-    assign cmoh_set   =  cmoh_nline[0                         +: HPDcacheCfg.setWidth];
-    assign cmoh_tag   =  cmoh_nline[HPDcacheCfg.setWidth      +: HPDcacheCfg.tagWidth];
-
-    assign cmoh_dir_check_nline_hit = |dir_check_nline_hit_way_i;
-
     assign core_rsp = '{
         rdata: '0,
         sid: req_sid_i,
@@ -187,6 +166,8 @@ import hpdcache_pkg::*;
         error: 1'b0,
         aborted: 1'b0
     };
+
+    assign req_ready_o = (cmoh_fsm_q == CMOH_IDLE) && (!core_rsp_rok || core_rsp_r);
 
     always_comb
     begin : cmoh_fsm_comb
@@ -210,9 +191,6 @@ import hpdcache_pkg::*;
         flush_all_o = 1'b0;
         inval_all_o = 1'b0;
 
-        dir_check_nline_o     = 1'b0;
-        dir_check_nline_set_o = cmoh_set;
-        dir_check_nline_tag_o = cmoh_tag;
         dir_check_entry_o     = 1'b0;
         dir_check_entry_set_o = cmoh_set_q;
         dir_check_entry_way_o = cmoh_way_q;
@@ -233,12 +211,8 @@ import hpdcache_pkg::*;
         core_rsp_w      = 1'b0;
         core_rsp_send_d = core_rsp_send_q;
 
-        req_ready_o = 1'b0;
-
         unique case (cmoh_fsm_q)
             CMOH_IDLE: begin
-                req_ready_o = ~core_rsp_rok | core_rsp_r;
-
                 if (core_rsp_r) begin
                     core_rsp_send_d = 1'b0;
                 end
@@ -250,31 +224,10 @@ import hpdcache_pkg::*;
                     cmoh_way_reset = 1'b1;
 
                     unique case (1'b1)
-                        req_op_i.is_fence: begin
-                            core_rsp_send_d = core_rsp_w;
-                            cmoh_fsm_d = CMOH_IDLE;
-                        end
-                        req_op_i.is_inval_by_nline: begin
-                            if (valid_set_en_i) begin
-                                cmoh_fsm_d = CMOH_INVAL_CHECK_NLINE;
-                            end else begin
-                                core_rsp_send_d = core_rsp_w;
-                                cmoh_fsm_d = CMOH_IDLE;
-                            end
-                        end
                         req_op_i.is_inval_all: begin
                             if (valid_set_en_i) begin
                                 cmoh_inval_set_reset = 1'b1;
                                 cmoh_fsm_d = CMOH_INVAL_SET;
-                            end else begin
-                                core_rsp_send_d = core_rsp_w;
-                                cmoh_fsm_d = CMOH_IDLE;
-                            end
-                        end
-                        req_op_i.is_flush_by_nline: begin
-                            if (dirty_set_en_i) begin
-                                cmoh_flush_req_inval_d = 1'b0;
-                                cmoh_fsm_d = CMOH_FLUSH_NLINE_FIRST;
                             end else begin
                                 core_rsp_send_d = core_rsp_w;
                                 cmoh_fsm_d = CMOH_IDLE;
@@ -285,15 +238,6 @@ import hpdcache_pkg::*;
                                 cmoh_flush_set_reset = 1'b1;
                                 cmoh_flush_req_inval_d = 1'b0;
                                 cmoh_fsm_d = CMOH_FLUSH_ALL_FIRST;
-                            end else begin
-                                core_rsp_send_d = core_rsp_w;
-                                cmoh_fsm_d = CMOH_IDLE;
-                            end
-                        end
-                        req_op_i.is_flush_inval_by_nline: begin
-                            if (valid_set_en_i) begin
-                                cmoh_flush_req_inval_d = 1'b1;
-                                cmoh_fsm_d = CMOH_FLUSH_NLINE_FIRST;
                             end else begin
                                 core_rsp_send_d = core_rsp_w;
                                 cmoh_fsm_d = CMOH_IDLE;
@@ -312,52 +256,21 @@ import hpdcache_pkg::*;
                     endcase
                 end
             end
-            CMOH_INVAL_CHECK_NLINE: begin
-                dir_check_nline_o = 1'b1;
-                cmoh_fsm_d = CMOH_INVAL_SET;
-            end
             CMOH_INVAL_SET: begin
-                unique case (1'b1)
-                    //  The CMO requests the invalidation of a given cacheline (or flush with
-                    //  invalidation when the cache does not support WB policy)
-                    cmoh_op_q.is_inval_by_nline,
-                    cmoh_op_q.is_flush_inval_by_nline: begin
-                        /* FIXME this adds a DIR to DIR timing path. We should probably delay the
-                         *       invalidation of one cycle to ease the timing closure */
-                        dir_updt_o       = cmoh_dir_check_nline_hit;
-                        dir_updt_set_o   = cmoh_set;
-                        dir_updt_way_o   = dir_check_nline_hit_way_i;
-                        dir_updt_valid_o = 1'b0;
-                        dir_updt_wback_o = 1'b0;
-                        dir_updt_dirty_o = 1'b0;
-                        dir_updt_fetch_o = 1'b0;
-                        dir_updt_tag_o   = '0;
-
-                        core_rsp_send_d = core_rsp_rok;
-                        cmoh_fsm_d      = CMOH_IDLE;
-                    end
-
-                    //  The CMO requests a full invalidation (or flush with invalidation when the
-                    //  cache does not support WB policy)
-                    cmoh_op_q.is_inval_all,
-                    cmoh_op_q.is_flush_inval_all:
-                    begin
-                        dir_updt_o       = 1'b1;
-                        dir_updt_set_o   = cmoh_set_q;
-                        dir_updt_way_o   = {HPDcacheCfg.u.ways{1'b1}};
-                        dir_updt_valid_o = 1'b0;
-                        dir_updt_wback_o = 1'b0;
-                        dir_updt_dirty_o = 1'b0;
-                        dir_updt_fetch_o = 1'b0;
-                        dir_updt_tag_o   = '0;
-                        cmoh_set_incr    = 1'b1;
-                        if (cmoh_set_last) begin
-                            inval_all_o = 1'b1;
-                            core_rsp_send_d = core_rsp_rok;
-                            cmoh_fsm_d = CMOH_IDLE;
-                        end
-                    end
-                endcase
+                dir_updt_o       = 1'b1;
+                dir_updt_set_o   = cmoh_set_q;
+                dir_updt_way_o   = {HPDcacheCfg.u.ways{1'b1}};
+                dir_updt_valid_o = 1'b0;
+                dir_updt_wback_o = 1'b0;
+                dir_updt_dirty_o = 1'b0;
+                dir_updt_fetch_o = 1'b0;
+                dir_updt_tag_o   = '0;
+                cmoh_set_incr    = 1'b1;
+                if (cmoh_set_last) begin
+                    inval_all_o = 1'b1;
+                    core_rsp_send_d = core_rsp_rok;
+                    cmoh_fsm_d = CMOH_IDLE;
+                end
             end
             CMOH_FLUSH_ALL_FIRST: begin
                 if (HPDcacheCfg.u.wbEn) begin
@@ -434,44 +347,6 @@ import hpdcache_pkg::*;
                 if (flush_empty_i && !flush_alloc_o) begin
                     flush_all_o = 1'b1;
                     inval_all_o = cmoh_flush_req_inval_q;
-                    core_rsp_send_d = core_rsp_rok;
-                    cmoh_fsm_d = CMOH_IDLE;
-                end
-            end
-            CMOH_FLUSH_NLINE_FIRST: begin
-                if (HPDcacheCfg.u.wbEn) begin
-                    if (cmoh_flush_req_wok) begin
-                        dir_check_nline_o = 1'b1;
-                        cmoh_flush_req_valid_d = 1'b1;
-                        cmoh_fsm_d = CMOH_FLUSH_NLINE_NEXT;
-                    end
-                end else if (cmoh_flush_req_inval_q) begin
-                    cmoh_fsm_d = CMOH_INVAL_CHECK_NLINE;
-                end else begin
-                    core_rsp_send_d = core_rsp_rok;
-                    cmoh_fsm_d = CMOH_IDLE;
-                end
-            end
-            CMOH_FLUSH_NLINE_NEXT: begin
-                cmoh_flush_req_valid_d = 1'b0;
-                if (cmoh_flush_req_valid_q) begin
-                    /* FIXME this adds a DIR to DIR timing path. We should probably delay the
-                     *       invalidation of one cycle to ease the timing closure */
-                    dir_updt_o       = cmoh_dir_check_nline_hit;
-                    dir_updt_set_o   = cmoh_set;
-                    dir_updt_way_o   = dir_check_nline_hit_way_i;
-                    dir_updt_valid_o = ~cmoh_flush_req_inval_q;
-                    dir_updt_wback_o = ~cmoh_flush_req_inval_q & dir_check_nline_wback_i;
-                    dir_updt_dirty_o = 1'b0;
-                    dir_updt_fetch_o = 1'b0;
-                    dir_updt_tag_o   = cmoh_tag;
-                    cmoh_flush_req_set = cmoh_set;
-                    cmoh_flush_req_tag = cmoh_tag;
-                    cmoh_flush_req_way = dir_check_nline_hit_way_i;
-                end
-
-                //  Make sure that all requests have been processed
-                if (flush_empty_i && !flush_alloc_o) begin
                     core_rsp_send_d = core_rsp_rok;
                     cmoh_fsm_d = CMOH_IDLE;
                 end
@@ -564,12 +439,9 @@ import hpdcache_pkg::*;
         begin : cmoh_flush_req_w_comb
             cmoh_flush_req_w = 1'b0;
             if (cmoh_flush_req_valid_q) begin
-                unique case (cmoh_fsm_q)
-                    CMOH_FLUSH_ALL_NEXT, CMOH_FLUSH_ALL_LAST:
-                        cmoh_flush_req_w = dir_check_entry_valid_i & dir_check_entry_dirty_i;
-                    CMOH_FLUSH_NLINE_NEXT:
-                        cmoh_flush_req_w = cmoh_dir_check_nline_hit & dir_check_nline_dirty_i;
-                endcase
+                if (cmoh_fsm_q inside {CMOH_FLUSH_ALL_NEXT, CMOH_FLUSH_ALL_LAST}) begin
+                    cmoh_flush_req_w = dir_check_entry_valid_i & dir_check_entry_dirty_i;
+                end
             end
         end
 
@@ -608,12 +480,8 @@ import hpdcache_pkg::*;
 //  {{{
 `ifndef HPDCACHE_ASSERT_OFF
     assert property (@(posedge clk_i) disable iff (rst_ni !== 1'b1)
-            req_valid_i -> $onehot({req_op_i.is_fence,
-                                    req_op_i.is_inval_by_nline,
-                                    req_op_i.is_inval_all,
-                                    req_op_i.is_flush_by_nline,
+            req_valid_i -> $onehot({req_op_i.is_inval_all,
                                     req_op_i.is_flush_all,
-                                    req_op_i.is_flush_inval_by_nline,
                                     req_op_i.is_flush_inval_all})) else
                     $error("cmo_handler: invalid request");
 

--- a/rtl/src/hpdcache_cmo.sv
+++ b/rtl/src/hpdcache_cmo.sv
@@ -4,19 +4,6 @@
  *  Copyright 2025 Inria, Universite Grenoble-Alpes, TIMA
  *
  *  SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
- *
- *  Licensed under the Solderpad Hardware License v 2.1 (the “License”); you
- *  may not use this file except in compliance with the License, or, at your
- *  option, the Apache License version 2.0. You may obtain a copy of the
- *  License at
- *
- *  https://solderpad.org/licenses/SHL-2.1/
- *
- *  Unless required by applicable law or agreed to in writing, any work
- *  distributed under the License is distributed on an “AS IS” BASIS, WITHOUT
- *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- *  License for the specific language governing permissions and limitations
- *  under the License.
  */
 /*
  *  Authors       : Cesar Fuguet
@@ -51,14 +38,6 @@ import hpdcache_pkg::*;
     input  logic                  clk_i,
     input  logic                  rst_ni,
 
-    //  Global control signals
-    //  {{{
-    input  logic                  wbuf_empty_i,
-    input  logic                  mshr_empty_i,
-    input  logic                  rtab_empty_i,
-    input  logic                  ctrl_empty_i,
-    //  }}}
-
     //  Request interface
     //  {{{
     input  logic                  req_valid_i,
@@ -69,7 +48,6 @@ import hpdcache_pkg::*;
     input  hpdcache_req_sid_t     req_sid_i,
     input  hpdcache_req_tid_t     req_tid_i,
     input  logic                  req_need_rsp_i,
-    output logic                  req_wait_o,
     //  }}}
 
     //  Dirty/Valid tracking interface
@@ -89,11 +67,6 @@ import hpdcache_pkg::*;
     input  logic                  core_rsp_ready_i,
     output logic                  core_rsp_valid_o,
     output hpdcache_rsp_t         core_rsp_o,
-    //  }}}
-
-    //  Write Buffer Interface
-    //  {{{
-    output logic                  wbuf_flush_all_o,
     //  }}}
 
     //  Cache Directory Interface
@@ -138,8 +111,6 @@ import hpdcache_pkg::*;
 //  {{{
     typedef enum {
         CMOH_IDLE = 0,
-        CMOH_FENCE_WAIT_WBUF_RTAB_EMPTY,
-        CMOH_WAIT_MSHR_RTAB_EMPTY,
         CMOH_INVAL_CHECK_NLINE,
         CMOH_INVAL_SET,
         CMOH_FLUSH_ALL_FIRST,
@@ -207,9 +178,6 @@ import hpdcache_pkg::*;
     assign cmoh_set   =  cmoh_nline[0                         +: HPDcacheCfg.setWidth];
     assign cmoh_tag   =  cmoh_nline[HPDcacheCfg.setWidth      +: HPDcacheCfg.tagWidth];
 
-    assign req_wait_o  = (cmoh_fsm_q == CMOH_FENCE_WAIT_WBUF_RTAB_EMPTY) |
-                         (cmoh_fsm_q == CMOH_WAIT_MSHR_RTAB_EMPTY);
-
     assign cmoh_dir_check_nline_hit = |dir_check_nline_hit_way_i;
 
     assign core_rsp = '{
@@ -258,8 +226,6 @@ import hpdcache_pkg::*;
         dir_updt_fetch_o = 1'b0;
         dir_updt_tag_o   = '0;
 
-        wbuf_flush_all_o = 1'b0;
-
         cmoh_flush_req_set = '0;
         cmoh_flush_req_way = '0;
         cmoh_flush_req_tag = '0;
@@ -279,93 +245,71 @@ import hpdcache_pkg::*;
 
                 if (req_valid_i && req_ready_o) begin
                     core_rsp_w = req_need_rsp_i;
+                    cmoh_op_d = req_op_i;
+                    cmoh_addr_d = req_addr_i;
+                    cmoh_way_reset = 1'b1;
 
                     unique case (1'b1)
                         req_op_i.is_fence: begin
-                            //  request to the write buffer to send all open entries
-                            wbuf_flush_all_o = rtab_empty_i;
-
-                            //  then wait for the write buffer to be empty
-                            if (!rtab_empty_i || !wbuf_empty_i) begin
-                                cmoh_fsm_d = CMOH_FENCE_WAIT_WBUF_RTAB_EMPTY;
+                            core_rsp_send_d = core_rsp_w;
+                            cmoh_fsm_d = CMOH_IDLE;
+                        end
+                        req_op_i.is_inval_by_nline: begin
+                            if (valid_set_en_i) begin
+                                cmoh_fsm_d = CMOH_INVAL_CHECK_NLINE;
                             end else begin
-                                core_rsp_send_d = req_need_rsp_i;
+                                core_rsp_send_d = core_rsp_w;
+                                cmoh_fsm_d = CMOH_IDLE;
                             end
                         end
-
-                        req_op_i.is_inval_by_nline,
-                        req_op_i.is_inval_all,
-                        req_op_i.is_flush_by_nline,
-                        req_op_i.is_flush_all,
-                        req_op_i.is_flush_inval_by_nline,
+                        req_op_i.is_inval_all: begin
+                            if (valid_set_en_i) begin
+                                cmoh_inval_set_reset = 1'b1;
+                                cmoh_fsm_d = CMOH_INVAL_SET;
+                            end else begin
+                                core_rsp_send_d = core_rsp_w;
+                                cmoh_fsm_d = CMOH_IDLE;
+                            end
+                        end
+                        req_op_i.is_flush_by_nline: begin
+                            if (dirty_set_en_i) begin
+                                cmoh_flush_req_inval_d = 1'b0;
+                                cmoh_fsm_d = CMOH_FLUSH_NLINE_FIRST;
+                            end else begin
+                                core_rsp_send_d = core_rsp_w;
+                                cmoh_fsm_d = CMOH_IDLE;
+                            end
+                        end
+                        req_op_i.is_flush_all: begin
+                            if (dirty_set_en_i) begin
+                                cmoh_flush_set_reset = 1'b1;
+                                cmoh_flush_req_inval_d = 1'b0;
+                                cmoh_fsm_d = CMOH_FLUSH_ALL_FIRST;
+                            end else begin
+                                core_rsp_send_d = core_rsp_w;
+                                cmoh_fsm_d = CMOH_IDLE;
+                            end
+                        end
+                        req_op_i.is_flush_inval_by_nline: begin
+                            if (valid_set_en_i) begin
+                                cmoh_flush_req_inval_d = 1'b1;
+                                cmoh_fsm_d = CMOH_FLUSH_NLINE_FIRST;
+                            end else begin
+                                core_rsp_send_d = core_rsp_w;
+                                cmoh_fsm_d = CMOH_IDLE;
+                            end
+                        end
                         req_op_i.is_flush_inval_all: begin
-                            cmoh_op_d = req_op_i;
-                            cmoh_addr_d = req_addr_i;
-                            cmoh_way_reset = 1'b1;
-                            cmoh_fsm_d = CMOH_WAIT_MSHR_RTAB_EMPTY;
+                            if (valid_set_en_i) begin
+                                cmoh_inval_set_reset = 1'b1;
+                                cmoh_flush_req_inval_d = 1'b1;
+                                cmoh_fsm_d = CMOH_FLUSH_ALL_FIRST;
+                            end else begin
+                                core_rsp_send_d = core_rsp_w;
+                                cmoh_fsm_d = CMOH_IDLE;
+                            end
                         end
                     endcase
-                end
-            end
-            CMOH_FENCE_WAIT_WBUF_RTAB_EMPTY: begin
-                wbuf_flush_all_o = rtab_empty_i;
-                if (wbuf_empty_i && rtab_empty_i) begin
-                    core_rsp_send_d = core_rsp_rok;
-                    cmoh_fsm_d = CMOH_IDLE;
-                end
-            end
-            CMOH_WAIT_MSHR_RTAB_EMPTY: begin
-                if (mshr_empty_i && rtab_empty_i && ctrl_empty_i) begin
-                    unique if (cmoh_op_q.is_inval_by_nline) begin
-                        if (valid_set_en_i) begin
-                            cmoh_fsm_d = CMOH_INVAL_CHECK_NLINE;
-                        end else begin
-                            core_rsp_send_d = core_rsp_rok;
-                            cmoh_fsm_d = CMOH_IDLE;
-                        end
-                    end else if (cmoh_op_q.is_inval_all) begin
-                        if (valid_set_en_i) begin
-                            cmoh_inval_set_reset = 1'b1;
-                            cmoh_fsm_d = CMOH_INVAL_SET;
-                        end else begin
-                            core_rsp_send_d = core_rsp_rok;
-                            cmoh_fsm_d = CMOH_IDLE;
-                        end
-                    end else if (cmoh_op_q.is_flush_by_nline) begin
-                        if (dirty_set_en_i) begin
-                            cmoh_flush_req_inval_d = 1'b0;
-                            cmoh_fsm_d = CMOH_FLUSH_NLINE_FIRST;
-                        end else begin
-                            core_rsp_send_d = core_rsp_rok;
-                            cmoh_fsm_d = CMOH_IDLE;
-                        end
-                    end else if (cmoh_op_q.is_flush_all) begin
-                        if (dirty_set_en_i) begin
-                            cmoh_flush_set_reset = 1'b1;
-                            cmoh_flush_req_inval_d = 1'b0;
-                            cmoh_fsm_d = CMOH_FLUSH_ALL_FIRST;
-                        end else begin
-                            core_rsp_send_d = core_rsp_rok;
-                            cmoh_fsm_d = CMOH_IDLE;
-                        end
-                    end else if (cmoh_op_q.is_flush_inval_by_nline) begin
-                        if (valid_set_en_i) begin
-                            cmoh_flush_req_inval_d = 1'b1;
-                            cmoh_fsm_d = CMOH_FLUSH_NLINE_FIRST;
-                        end else begin
-                            core_rsp_send_d = core_rsp_rok;
-                            cmoh_fsm_d = CMOH_IDLE;
-                        end
-                    end else if (cmoh_op_q.is_flush_inval_all) begin
-                        if (valid_set_en_i) begin
-                            cmoh_inval_set_reset = 1'b1;
-                            cmoh_flush_req_inval_d = 1'b1;
-                            cmoh_fsm_d = CMOH_FLUSH_ALL_FIRST;
-                        end else begin
-                            core_rsp_send_d = core_rsp_rok;
-                            cmoh_fsm_d = CMOH_IDLE;
-                        end
-                    end
                 end
             end
             CMOH_INVAL_CHECK_NLINE: begin
@@ -678,5 +622,5 @@ import hpdcache_pkg::*;
                     $error("cmo_handler: new request received while busy");
 `endif
 //  }}}
-
 endmodule
+// vim: ts=4 : sts=4 : sw=4 : et : tw=100 : spell : spelllang=en : fdm=marker

--- a/rtl/src/hpdcache_ctrl.sv
+++ b/rtl/src/hpdcache_ctrl.sv
@@ -171,7 +171,6 @@ import hpdcache_pkg::*;
     output logic                  uc_req_need_rsp_o,
     output hpdcache_way_vector_t  uc_req_dir_hit_way_o,
     output hpdcache_req_data_t    uc_req_old_data_o,
-    input  logic                  uc_wbuf_flush_all_i,
     input  logic                  uc_data_amo_write_i,
     input  logic                  uc_data_amo_write_enable_i,
     input  hpdcache_set_t         uc_data_amo_write_set_i,
@@ -186,7 +185,6 @@ import hpdcache_pkg::*;
 
     //      Cache Management Operation (CMO)
     input  logic                  cmo_busy_i,
-    input  logic                  cmo_wait_i,
     output logic                  cmo_req_valid_o,
     output hpdcache_cmoh_op_t     cmo_req_op_o,
     output hpdcache_req_addr_t    cmo_req_addr_o,
@@ -200,7 +198,6 @@ import hpdcache_pkg::*;
     output logic                  cmo_valid_set_en_o,
     output hpdcache_set_t         cmo_valid_min_set_o,
     output hpdcache_set_t         cmo_valid_max_set_o,
-    input  logic                  cmo_wbuf_flush_all_i,
     input  logic                  cmo_flush_all_i,
     input  logic                  cmo_inval_all_i,
     input  logic                  cmo_dir_check_nline_i,
@@ -432,6 +429,7 @@ import hpdcache_pkg::*;
     logic                    st1_rtab_check;
     logic                    st1_rtab_check_hit;
     logic                    st1_no_pend_trans;
+    logic                    st1_wbuf_flush_all;
 
     logic                    scrub_req_valid;
     logic                    scrub_req_ready;
@@ -726,13 +724,13 @@ import hpdcache_pkg::*;
         .wbuf_read_hit_i,
         .wbuf_write_uncacheable_o,
         .wbuf_read_flush_hit_o,
+        .wbuf_flush_all_o                   (st1_wbuf_flush_all),
 
         .uc_busy_i,
         .uc_req_valid_o,
         .uc_core_rsp_ready_o,
 
         .cmo_busy_i,
-        .cmo_wait_i,
         .cmo_req_valid_o,
         .cmo_core_rsp_ready_o,
 
@@ -1151,7 +1149,7 @@ import hpdcache_pkg::*;
     assign wbuf_write_addr_o = st1_req_addr;
     assign wbuf_write_data_o = st1_req.req.wdata;
     assign wbuf_write_be_o   = st1_req.req.be;
-    assign wbuf_flush_all_o  = cmo_wbuf_flush_all_i | uc_wbuf_flush_all_i | wbuf_flush_i;
+    assign wbuf_flush_all_o  = st1_wbuf_flush_all | wbuf_flush_i;
     //  }}}
 
     //  Miss handler outputs

--- a/rtl/src/hpdcache_ctrl.sv
+++ b/rtl/src/hpdcache_ctrl.sv
@@ -71,9 +71,6 @@ import hpdcache_pkg::*;
     //      Force the write buffer to send all pending writes
     input  logic                  wbuf_flush_i,
 
-    //      Global control signals
-    output logic                  cachedir_hit_o,
-
     //      Miss handler interface
     output logic                  st0_mshr_check_o,
     output hpdcache_req_offset_t  st0_mshr_check_offset_o,
@@ -188,7 +185,6 @@ import hpdcache_pkg::*;
     output logic                  cmo_req_valid_o,
     output hpdcache_cmoh_op_t     cmo_req_op_o,
     output hpdcache_req_addr_t    cmo_req_addr_o,
-    output hpdcache_req_data_t    cmo_req_wdata_o,
     output hpdcache_req_sid_t     cmo_req_sid_o,
     output hpdcache_req_tid_t     cmo_req_tid_o,
     output logic                  cmo_req_need_rsp_o,
@@ -200,12 +196,6 @@ import hpdcache_pkg::*;
     output hpdcache_set_t         cmo_valid_max_set_o,
     input  logic                  cmo_flush_all_i,
     input  logic                  cmo_inval_all_i,
-    input  logic                  cmo_dir_check_nline_i,
-    input  hpdcache_set_t         cmo_dir_check_nline_set_i,
-    input  hpdcache_tag_t         cmo_dir_check_nline_tag_i,
-    output hpdcache_way_vector_t  cmo_dir_check_nline_hit_way_o,
-    output logic                  cmo_dir_check_nline_wback_o,
-    output logic                  cmo_dir_check_nline_dirty_o,
     input  logic                  cmo_dir_check_entry_i,
     input  hpdcache_set_t         cmo_dir_check_entry_set_i,
     input  hpdcache_way_vector_t  cmo_dir_check_entry_way_i,
@@ -347,6 +337,7 @@ import hpdcache_pkg::*;
     logic                    st0_req_is_amo;
     logic                    st0_req_is_cmo_fence;
     logic                    st0_req_is_cmo_inval;
+    logic                    st0_req_is_cmo_flush;
     logic                    st0_req_is_cmo_prefetch;
     logic                    st0_req_is_partial;
     logic                    st0_req_cachedir_read;
@@ -390,7 +381,13 @@ import hpdcache_pkg::*;
     logic                    st1_req_is_amo_min;
     logic                    st1_req_is_amo_minu;
     logic                    st1_req_is_cmo_inval;
+    logic                    st1_req_is_cmo_inval_nline;
+    logic                    st1_req_is_cmo_inval_all;
     logic                    st1_req_is_cmo_flush;
+    logic                    st1_req_is_cmo_flush_nline;
+    logic                    st1_req_is_cmo_flush_all;
+    logic                    st1_req_is_cmo_flush_inval_nline;
+    logic                    st1_req_is_cmo_flush_inval_all;
     logic                    st1_req_is_cmo_fence;
     logic                    st1_req_is_cmo_prefetch;
     logic                    st1_req_is_partial;
@@ -507,13 +504,14 @@ import hpdcache_pkg::*;
     end
 
     //     Decode operation in stage 0
-    assign st0_req_is_uncacheable  =     st0_req.req.pma.uncacheable;
-    assign st0_req_is_load         =         is_load(st0_req.req.op) & ~st0_req.err_scrubbing;
-    assign st0_req_is_scrub        =         is_load(st0_req.req.op) &  st0_req.err_scrubbing;
-    assign st0_req_is_store        =        is_store(st0_req.req.op);
-    assign st0_req_is_amo          =          is_amo(st0_req.req.op);
-    assign st0_req_is_cmo_fence    =    is_cmo_fence(st0_req.req.op);
-    assign st0_req_is_cmo_inval    =    is_cmo_inval(st0_req.req.op);
+    assign st0_req_is_uncacheable  = st0_req.req.pma.uncacheable;
+    assign st0_req_is_load         = is_load(st0_req.req.op) & ~st0_req.err_scrubbing;
+    assign st0_req_is_scrub        = is_load(st0_req.req.op) &  st0_req.err_scrubbing;
+    assign st0_req_is_store        = is_store(st0_req.req.op);
+    assign st0_req_is_amo          = is_amo(st0_req.req.op);
+    assign st0_req_is_cmo_fence    = is_cmo_fence(st0_req.req.op);
+    assign st0_req_is_cmo_inval    = is_cmo_inval(st0_req.req.op);
+    assign st0_req_is_cmo_flush    = is_cmo_flush(st0_req.req.op);
     assign st0_req_is_cmo_prefetch = is_cmo_prefetch(st0_req.req.op);
 
     assign st0_req_is_partial = (hpdcache_uint'(st0_req.req.size) < HPDcacheCfg.wordByteIdxWidth);
@@ -555,34 +553,43 @@ import hpdcache_pkg::*;
 
     //         A requester can ask to abort a request it initiated on the
     //         previous cycle (stage 0). Useful in case of TLB miss for example
-    assign st1_req_abort           = core_req_abort_i & ~st1_req.req.phys_indexed;
+    assign st1_req_abort = core_req_abort_i & ~st1_req.req.phys_indexed;
 
-    assign st1_req_is_uncacheable  = ~cfg_enable_i | st1_req.req.pma.uncacheable;
-    assign st1_req_is_load         =         is_load(st1_req.req.op) & ~st1_req.err_scrubbing;
-    assign st1_req_is_store        =        is_store(st1_req.req.op);
-    assign st1_req_is_amo          =          is_amo(st1_req.req.op);
-    assign st1_req_is_amo_lr       =       is_amo_lr(st1_req.req.op);
-    assign st1_req_is_amo_sc       =       is_amo_sc(st1_req.req.op);
-    assign st1_req_is_amo_swap     =     is_amo_swap(st1_req.req.op);
-    assign st1_req_is_amo_add      =      is_amo_add(st1_req.req.op);
-    assign st1_req_is_amo_and      =      is_amo_and(st1_req.req.op);
-    assign st1_req_is_amo_or       =       is_amo_or(st1_req.req.op);
-    assign st1_req_is_amo_xor      =      is_amo_xor(st1_req.req.op);
-    assign st1_req_is_amo_max      =      is_amo_max(st1_req.req.op);
-    assign st1_req_is_amo_maxu     =     is_amo_maxu(st1_req.req.op);
-    assign st1_req_is_amo_min      =      is_amo_min(st1_req.req.op);
-    assign st1_req_is_amo_minu     =     is_amo_minu(st1_req.req.op);
-    assign st1_req_is_cmo_inval    =    is_cmo_inval(st1_req.req.op);
-    assign st1_req_is_cmo_flush    =    is_cmo_flush(st1_req.req.op);
-    assign st1_req_is_cmo_fence    =    is_cmo_fence(st1_req.req.op);
-    assign st1_req_is_cmo_prefetch = is_cmo_prefetch(st1_req.req.op);
+    assign st1_req_is_uncacheable = ~cfg_enable_i | st1_req.req.pma.uncacheable;
+
+    assign st1_req_is_load  = is_load(st1_req.req.op) & ~st1_req.err_scrubbing;
+    assign st1_req_is_store = is_store(st1_req.req.op);
+
+    assign st1_req_is_amo      = is_amo(st1_req.req.op);
+    assign st1_req_is_amo_lr   = is_amo_lr(st1_req.req.op);
+    assign st1_req_is_amo_sc   = is_amo_sc(st1_req.req.op);
+    assign st1_req_is_amo_swap = is_amo_swap(st1_req.req.op);
+    assign st1_req_is_amo_add  = is_amo_add(st1_req.req.op);
+    assign st1_req_is_amo_and  = is_amo_and(st1_req.req.op);
+    assign st1_req_is_amo_or   = is_amo_or(st1_req.req.op);
+    assign st1_req_is_amo_xor  = is_amo_xor(st1_req.req.op);
+    assign st1_req_is_amo_max  = is_amo_max(st1_req.req.op);
+    assign st1_req_is_amo_maxu = is_amo_maxu(st1_req.req.op);
+    assign st1_req_is_amo_min  = is_amo_min(st1_req.req.op);
+    assign st1_req_is_amo_minu = is_amo_minu(st1_req.req.op);
+
+    assign st1_req_is_cmo_inval             = is_cmo_inval(st1_req.req.op);
+    assign st1_req_is_cmo_inval_nline       = is_cmo_inval_by_nline(st1_req.req.op);
+    assign st1_req_is_cmo_inval_all         = is_cmo_inval_all(st1_req.req.op);
+    assign st1_req_is_cmo_flush             = is_cmo_flush(st1_req.req.op);
+    assign st1_req_is_cmo_flush_nline       = is_cmo_flush_by_nline(st1_req.req.op);
+    assign st1_req_is_cmo_flush_all         = is_cmo_flush_all(st1_req.req.op);
+    assign st1_req_is_cmo_flush_inval_nline = is_cmo_flush_inval_by_nline(st1_req.req.op);
+    assign st1_req_is_cmo_flush_inval_all   = is_cmo_flush_inval_all(st1_req.req.op);
+    assign st1_req_is_cmo_fence             = is_cmo_fence(st1_req.req.op);
+    assign st1_req_is_cmo_prefetch          = is_cmo_prefetch(st1_req.req.op);
 
     assign st1_req_is_partial = (hpdcache_uint'(st1_req.req.size) < HPDcacheCfg.wordByteIdxWidth);
 
     //  Decode write-policy hint
-    assign st1_req_wr_wt           = (st1_req.req.pma.wr_policy_hint == HPDCACHE_WR_POLICY_WT);
-    assign st1_req_wr_wb           = (st1_req.req.pma.wr_policy_hint == HPDCACHE_WR_POLICY_WB);
-    assign st1_req_wr_auto         = (st1_req.req.pma.wr_policy_hint == HPDCACHE_WR_POLICY_AUTO);
+    assign st1_req_wr_wt   = (st1_req.req.pma.wr_policy_hint == HPDCACHE_WR_POLICY_WT);
+    assign st1_req_wr_wb   = (st1_req.req.pma.wr_policy_hint == HPDCACHE_WR_POLICY_WB);
+    assign st1_req_wr_auto = (st1_req.req.pma.wr_policy_hint == HPDCACHE_WR_POLICY_AUTO);
     //  }}}
 
     //  Cache controller protocol engine
@@ -610,6 +617,7 @@ import hpdcache_pkg::*;
         .st0_req_is_amo_i                   (st0_req_is_amo),
         .st0_req_is_cmo_fence_i             (st0_req_is_cmo_fence),
         .st0_req_is_cmo_inval_i             (st0_req_is_cmo_inval),
+        .st0_req_is_cmo_flush_i             (st0_req_is_cmo_flush),
         .st0_req_is_cmo_prefetch_i          (st0_req_is_cmo_prefetch),
         .st0_req_is_partial_i               (st0_req_is_partial),
         .st0_req_mshr_check_o               (st0_mshr_check_o),
@@ -625,13 +633,17 @@ import hpdcache_pkg::*;
         .st1_req_is_store_i                 (st1_req_is_store),
         .st1_req_is_amo_i                   (st1_req_is_amo),
         .st1_req_is_cmo_inval_i             (st1_req_is_cmo_inval),
+        .st1_req_is_cmo_inval_nline_i       (st1_req_is_cmo_inval_nline),
         .st1_req_is_cmo_flush_i             (st1_req_is_cmo_flush),
+        .st1_req_is_cmo_flush_nline_i       (st1_req_is_cmo_flush_nline),
+        .st1_req_is_cmo_flush_inval_nline_i (st1_req_is_cmo_flush_inval_nline),
         .st1_req_is_cmo_fence_i             (st1_req_is_cmo_fence),
         .st1_req_is_cmo_prefetch_i          (st1_req_is_cmo_prefetch),
         .st1_req_is_partial_i               (st1_req_is_partial),
         .st1_req_wr_wt_i                    (st1_req_wr_wt),
         .st1_req_wr_wb_i                    (st1_req_wr_wb),
         .st1_req_wr_auto_i                  (st1_req_wr_auto),
+        .st1_dir_hit_i                      (st1_dir_hit),
         .st1_dir_hit_wback_i                (st1_dir_hit_wback),
         .st1_dir_hit_dirty_i                (st1_dir_hit_dirty),
         .st1_dir_hit_fetch_i                (st1_dir_hit_fetch),
@@ -708,7 +720,6 @@ import hpdcache_pkg::*;
         .st1_rtab_flush_not_ready_o         (st1_rtab_deps.flush_not_ready),
         .st1_rtab_pend_trans_o              (st1_rtab_deps.pend_trans),
 
-        .cachedir_hit_i                     (cachedir_hit_o),
         .cachedir_init_ready_i              (hpdcache_init_ready),
 
         .st1_mshr_alloc_ready_i             (st1_mshr_alloc_ready_i),
@@ -1054,13 +1065,6 @@ import hpdcache_pkg::*;
         .dir_inval_write_i             (inval_write_dir_i),
         .dir_inval_hit_o               (inval_hit_o),
 
-        .dir_cmo_check_nline_i         (cmo_dir_check_nline_i),
-        .dir_cmo_check_nline_set_i     (cmo_dir_check_nline_set_i),
-        .dir_cmo_check_nline_tag_i     (cmo_dir_check_nline_tag_i),
-        .dir_cmo_check_nline_hit_way_o (cmo_dir_check_nline_hit_way_o),
-        .dir_cmo_check_nline_wback_o   (cmo_dir_check_nline_wback_o),
-        .dir_cmo_check_nline_dirty_o   (cmo_dir_check_nline_dirty_o),
-
         .dir_cmo_check_entry_i         (cmo_dir_check_entry_i),
         .dir_cmo_check_entry_set_i     (cmo_dir_check_entry_set_i),
         .dir_cmo_check_entry_way_i     (cmo_dir_check_entry_way_i),
@@ -1139,9 +1143,7 @@ import hpdcache_pkg::*;
         .data_err_wdata_i              (err_dat_wdata)
     );
 
-    assign st1_dir_hit           = |st1_dir_hit_way;
-
-    assign cachedir_hit_o = st1_dir_hit;
+    assign st1_dir_hit = |st1_dir_hit_way;
     //  }}}
 
     //  Write buffer outputs
@@ -1205,23 +1207,12 @@ import hpdcache_pkg::*;
     //  CMO request handler outputs
     //  {{{
     assign cmo_req_addr_o                       = st1_req_addr;
-    assign cmo_req_wdata_o                      = st1_req.req.wdata;
     assign cmo_req_sid_o                        = st1_req.req.sid;
     assign cmo_req_tid_o                        = st1_req.req.tid;
     assign cmo_req_need_rsp_o                   = st1_req.req.need_rsp;
-    assign cmo_req_op_o.is_fence                = st1_req_is_cmo_fence;
-    assign cmo_req_op_o.is_inval_by_nline       = st1_req_is_cmo_inval &
-                                                  is_cmo_inval_by_nline(st1_req.req.op);
-    assign cmo_req_op_o.is_inval_all            = st1_req_is_cmo_inval &
-                                                  is_cmo_inval_all(st1_req.req.op);
-    assign cmo_req_op_o.is_flush_by_nline       = st1_req_is_cmo_flush &
-                                                  is_cmo_flush_by_nline(st1_req.req.op);
-    assign cmo_req_op_o.is_flush_all            = st1_req_is_cmo_flush &
-                                                  is_cmo_flush_all(st1_req.req.op);
-    assign cmo_req_op_o.is_flush_inval_by_nline = st1_req_is_cmo_flush &
-                                                  is_cmo_flush_inval_by_nline(st1_req.req.op);
-    assign cmo_req_op_o.is_flush_inval_all      = st1_req_is_cmo_flush &
-                                                  is_cmo_flush_inval_all(st1_req.req.op);
+    assign cmo_req_op_o.is_inval_all            = st1_req_is_cmo_inval_all;
+    assign cmo_req_op_o.is_flush_all            = st1_req_is_cmo_flush_all;
+    assign cmo_req_op_o.is_flush_inval_all      = st1_req_is_cmo_flush_inval_all;
     //  }}}
 
     //  ECC recovery handler

--- a/rtl/src/hpdcache_ctrl_pe.sv
+++ b/rtl/src/hpdcache_ctrl_pe.sv
@@ -50,6 +50,7 @@ import hpdcache_pkg::*;
     input  logic                   st0_req_is_amo_i,
     input  logic                   st0_req_is_cmo_fence_i,
     input  logic                   st0_req_is_cmo_inval_i,
+    input  logic                   st0_req_is_cmo_flush_i,
     input  logic                   st0_req_is_cmo_prefetch_i,
     input  logic                   st0_req_is_partial_i,
     output logic                   st0_req_mshr_check_o,
@@ -68,13 +69,17 @@ import hpdcache_pkg::*;
     input  logic                   st1_req_is_store_i,
     input  logic                   st1_req_is_amo_i,
     input  logic                   st1_req_is_cmo_inval_i,
+    input  logic                   st1_req_is_cmo_inval_nline_i,
     input  logic                   st1_req_is_cmo_flush_i,
+    input  logic                   st1_req_is_cmo_flush_nline_i,
+    input  logic                   st1_req_is_cmo_flush_inval_nline_i,
     input  logic                   st1_req_is_cmo_fence_i,
     input  logic                   st1_req_is_cmo_prefetch_i,
     input  logic                   st1_req_is_partial_i,
     input  logic                   st1_req_wr_wt_i,
     input  logic                   st1_req_wr_wb_i,
     input  logic                   st1_req_wr_auto_i,
+    input  logic                   st1_dir_hit_i,
     input  logic                   st1_dir_hit_wback_i,
     input  logic                   st1_dir_hit_dirty_i,
     input  logic                   st1_dir_hit_fetch_i,
@@ -161,7 +166,6 @@ import hpdcache_pkg::*;
 
     //   Cache directory
     //   {{{
-    input  logic                   cachedir_hit_i,
     input  logic                   cachedir_init_ready_i,
     //   }}}
 
@@ -491,11 +495,68 @@ import hpdcache_pkg::*;
                         wbuf_flush_all_o = 1'b1;
                         st1_rtab_alloc = 1'b1;
                         st1_nop = 1'b1;
-                    end
-                    //  Process the CMO (when no pending transaction)
-                    else begin
-                        cmo_req_valid_o = 1'b1;
-                        st1_nop         = 1'b1;
+                    end else begin
+                        //  Process fence CMO
+                        //  CMOs are only executed when there is no pending transaction (see above).
+                        //  Hence, the fence can be responded (if needed) when processed. No further
+                        //  treatment required.
+                        if (st1_req_is_cmo_fence_i) begin
+                            //  Acknowledge the core (if needed)
+                            st1_rsp_valid_o = st1_req_need_rsp_i;
+                        end
+                        //  Process inval cacheline CMO
+                        else if (st1_req_is_cmo_inval_nline_i) begin
+                            //  Invalidate the cacheline on cache hit
+                            st2_dir_updt_o       = st1_dir_hit_i;
+                            st2_dir_updt_valid_o = 1'b0;
+                            st2_dir_updt_wback_o = 1'b0;
+                            st2_dir_updt_dirty_o = 1'b0;
+                            st2_dir_updt_fetch_o = 1'b0;
+
+                            //  Acknowledge the core (if needed)
+                            st1_rsp_valid_o = st1_req_need_rsp_i;
+
+                            st1_nop = 1'b1;
+                        end
+                        //  Process flush cacheline CMO
+                        else if (st1_req_is_cmo_flush_nline_i) begin
+                            // allocate flush if there is a hit and the cacheline is dirty
+                            st2_flush_alloc_o = st1_dir_hit_dirty_i;
+
+                            // update the cacheline for flush
+                            st2_dir_updt_o = st1_dir_hit_dirty_i;
+                            st2_dir_updt_valid_o = 1'b1;
+                            st2_dir_updt_wback_o = 1'b1;
+                            st2_dir_updt_dirty_o = 1'b0;
+                            st2_dir_updt_fetch_o = 1'b0;
+
+                            //  Acknowledge the core (if needed)
+                            st1_rsp_valid_o = st1_req_need_rsp_i;
+
+                            st1_nop = 1'b1;
+                        end
+                        //  Process flush cacheline CMO
+                        else if (st1_req_is_cmo_flush_inval_nline_i) begin
+                            // allocate flush if there is a hit and the cacheline is dirty
+                            st2_flush_alloc_o = st1_dir_hit_dirty_i;
+
+                            // update the cacheline for flush
+                            st2_dir_updt_o = st1_dir_hit_i;
+                            st2_dir_updt_valid_o = 1'b0;
+                            st2_dir_updt_wback_o = 1'b0;
+                            st2_dir_updt_dirty_o = 1'b0;
+                            st2_dir_updt_fetch_o = 1'b0;
+
+                            //  Acknowledge the core (if needed)
+                            st1_rsp_valid_o = st1_req_need_rsp_i;
+
+                            st1_nop = 1'b1;
+                        end
+                        //  Process inval all and flush all CMO
+                        else begin
+                            cmo_req_valid_o = 1'b1;
+                            st1_nop         = 1'b1;
+                        end
 
                         //  If the request comes from the replay table, free the
                         //  corresponding RTAB entry
@@ -522,7 +583,7 @@ import hpdcache_pkg::*;
                     //  Process the unc request (when no pending transaction)
                     else begin
                         // cache miss
-                        if(!cachedir_hit_i) begin
+                        if(!st1_dir_hit_i) begin
                             uc_req_valid_o = 1'b1;
                             st1_nop        = 1'b1;
 
@@ -539,6 +600,8 @@ import hpdcache_pkg::*;
                             // if the target cacheline is dirty, we need to flush it.
                             if(st1_dir_hit_dirty_i) begin
                                 // flush controller is ready?
+                                // FIXME: this shall not happen as uncacheable requests are only
+                                //        process when there is no pending transactions
                                 if(!st1_flush_alloc_ready_i) begin
                                     st1_rtab_alloc = 1'b1;
                                     st1_rtab_flush_not_ready_o = 1'b1;
@@ -557,6 +620,8 @@ import hpdcache_pkg::*;
                                 end
                             end else begin
                                 // if the cacheline is being fetched?
+                                // FIXME: this shall not happen as uncacheable requests are only
+                                //        process when there is no pending transactions
                                 if(st1_dir_hit_fetch_i) begin
                                     st1_rtab_alloc = 1'b1;
                                     st1_rtab_dir_fetch_o = 1'b1;
@@ -653,7 +718,7 @@ import hpdcache_pkg::*;
                         else begin
                             st1_nop = 1'b1;
 
-                            if (cachedir_hit_i) begin
+                            if (st1_dir_hit_i) begin
                                 //  When the hit cacheline is dirty, flush its data to the memory
                                 st2_flush_alloc_o = st1_dir_hit_dirty_i;
 
@@ -698,7 +763,7 @@ import hpdcache_pkg::*;
                     begin
                         //  Cache miss
                         //  {{{
-                        if (!cachedir_hit_i) begin
+                        if (!st1_dir_hit_i) begin
                             //  A cache miss inserts a nop into the pipeline
                             st1_nop = 1'b1;
 
@@ -931,7 +996,7 @@ import hpdcache_pkg::*;
 
                         //  Cache miss
                         //  {{{
-                        else if (!cachedir_hit_i) begin
+                        else if (!st1_dir_hit_i) begin
                             //  Write is write-back
                             //  {{{
                             if (st1_req_wr_wb_i || (st1_req_wr_auto_i && cfg_default_wb_i))
@@ -1278,6 +1343,8 @@ import hpdcache_pkg::*;
 
                 if (st0_req_is_load_i         |
                     st0_req_is_cmo_prefetch_i |
+                    st0_req_is_cmo_inval_i    |
+                    st0_req_is_cmo_flush_i    |
                     st0_req_is_store_i        |
                     st0_req_is_amo_i)
                 begin

--- a/rtl/src/hpdcache_ctrl_pe.sv
+++ b/rtl/src/hpdcache_ctrl_pe.sv
@@ -178,6 +178,7 @@ import hpdcache_pkg::*;
     output logic                   wbuf_write_valid_o,
     output logic                   wbuf_write_uncacheable_o,
     output logic                   wbuf_read_flush_hit_o,
+    output logic                   wbuf_flush_all_o,
     //   }}}
 
     //   Flush controller
@@ -197,7 +198,6 @@ import hpdcache_pkg::*;
     //   Cache Management Operation (CMO)
     //   {{{
     input  logic                   cmo_busy_i,
-    input  logic                   cmo_wait_i,
     output logic                   cmo_req_valid_o,
     output logic                   cmo_core_rsp_ready_o,
     //   }}}
@@ -304,6 +304,7 @@ import hpdcache_pkg::*;
         wbuf_write_valid_o                  = 1'b0;
         wbuf_read_flush_hit_o               = 1'b0;
         wbuf_write_uncacheable_o            = 1'b0; // unused
+        wbuf_flush_all_o                    = 1'b0;
 
         core_req_ready_o                    = 1'b0;
         scrub_req_ready_o                   = 1'b0;
@@ -482,11 +483,27 @@ import hpdcache_pkg::*;
                          st1_req_is_cmo_flush_i ||
                          st1_req_is_cmo_fence_i)
                 begin
-                    cmo_req_valid_o = 1'b1;
-                    st1_nop         = 1'b1;
+                    //  There are pending transactions which must be completed and the
+                    //  request is not being replayed.
+                    //  When a CMO request is replayed, it is guaranteed
+                    //  that there is no other pending transaction.
+                    if (!st1_no_pend_trans_i && !st1_req_rtab_i) begin
+                        wbuf_flush_all_o = 1'b1;
+                        st1_rtab_alloc = 1'b1;
+                        st1_nop = 1'b1;
+                    end
+                    //  Process the CMO (when no pending transaction)
+                    else begin
+                        cmo_req_valid_o = 1'b1;
+                        st1_nop         = 1'b1;
 
-                    //  Performance event
-                    evt_cmo_req_o = 1'b1;
+                        //  If the request comes from the replay table, free the
+                        //  corresponding RTAB entry
+                        st1_rtab_commit_o = st1_req_rtab_i;
+
+                        //  Performance event
+                        evt_cmo_req_o = 1'b1;
+                    end
                 end
                 //  }}}
 
@@ -498,15 +515,17 @@ import hpdcache_pkg::*;
                     //  When an uncacheable request is replayed, it is guaranteed
                     //  that there is no other pending transaction.
                     if (!st1_no_pend_trans_i && !st1_req_rtab_i) begin
+                        wbuf_flush_all_o = 1'b1;
                         st1_rtab_alloc = 1'b1;
                         st1_nop = 1'b1;
                     end
-
+                    //  Process the unc request (when no pending transaction)
                     else begin
                         // cache miss
                         if(!cachedir_hit_i) begin
                             uc_req_valid_o = 1'b1;
                             st1_nop        = 1'b1;
+
                             //  If the request comes from the replay table, free the
                             //  corresponding RTAB entry
                             st1_rtab_commit_o = st1_req_rtab_i;
@@ -625,6 +644,7 @@ import hpdcache_pkg::*;
                         //  When an AMO request is replayed, it is guaranteed that there
                         //  is no other pending transaction.
                         if (!st1_no_pend_trans_i && !st1_req_rtab_i) begin
+                            wbuf_flush_all_o = 1'b1;
                             st1_rtab_alloc = 1'b1;
                             st1_nop = 1'b1;
                         end
@@ -1216,12 +1236,12 @@ import hpdcache_pkg::*;
 
             rtab_req_ready_o = rtab_req_valid_i
                                & ~refill_req_valid_i
-                               & (~cmo_busy_i | cmo_wait_i)
+                               & ~cmo_busy_i
                                & ~err_busy_i
                                & ~nop;
 
             refill_req_ready_o = refill_req_valid_i
-                                 & (~cmo_busy_i | cmo_wait_i)
+                                 & ~cmo_busy_i
                                  & (~err_busy_i | err_wait_i)
                                  & ~st1_req_valid_i
                                  & ~(st2_mshr_alloc_i | st2_dir_updt_i);

--- a/rtl/src/hpdcache_memctrl.sv
+++ b/rtl/src/hpdcache_memctrl.sv
@@ -491,7 +491,7 @@ import hpdcache_pkg::*;
 
     always_comb
     begin : dir_ctrl_comb
-        unique case (1'b1)
+        case (1'b1)
             //  Cache directory initialization
             ~init_q: begin
                 dir_addr    = init_set_q;
@@ -1137,7 +1137,8 @@ import hpdcache_pkg::*;
     end
 
     concurrent_dir_access_assert: assert property (@(posedge clk_i) disable iff (rst_ni !== 1'b1)
-            $onehot0({dir_match_i,
+            $onehot0({~init_q,
+                      dir_match_i,
                       dir_refill_i,
                       dir_inval_check_i,
                       dir_inval_write_i,

--- a/rtl/src/hpdcache_memctrl.sv
+++ b/rtl/src/hpdcache_memctrl.sv
@@ -90,13 +90,6 @@ import hpdcache_pkg::*;
     input  logic                                dir_inval_write_i,
     output logic                                dir_inval_hit_o,
 
-    input  logic                                dir_cmo_check_nline_i,
-    input  hpdcache_set_t                       dir_cmo_check_nline_set_i,
-    input  hpdcache_tag_t                       dir_cmo_check_nline_tag_i,
-    output hpdcache_way_vector_t                dir_cmo_check_nline_hit_way_o,
-    output logic                                dir_cmo_check_nline_wback_o,
-    output logic                                dir_cmo_check_nline_dirty_o,
-
     input  logic                                dir_cmo_check_entry_i,
     input  hpdcache_set_t                       dir_cmo_check_entry_set_i,
     input  hpdcache_way_vector_t                dir_cmo_check_entry_way_i,
@@ -533,14 +526,6 @@ import hpdcache_pkg::*;
             end
 
             //  Cache directory CMO match tag
-            dir_cmo_check_nline_i: begin
-                dir_addr    = dir_cmo_check_nline_set_i;
-                dir_cs      = '1;
-                dir_we      = '0;
-                dir_wentry  = '0;
-            end
-
-            //  Cache directory CMO match tag
             dir_cmo_check_entry_i: begin
                 dir_addr    = dir_cmo_check_entry_set_i;
                 dir_cs      = dir_cmo_check_entry_way_i;
@@ -644,7 +629,6 @@ import hpdcache_pkg::*;
     //  {{{
     hpdcache_tag_t [HPDcacheCfg.u.ways-1:0] dir_tags;
     hpdcache_way_vector_t req_hit;
-    hpdcache_way_vector_t cmo_hit;
     hpdcache_way_vector_t inval_hit;
 
     for (gen_i = 0; gen_i < int'(HPDcacheCfg.u.ways); gen_i++)
@@ -652,11 +636,9 @@ import hpdcache_pkg::*;
         assign dir_tags[gen_i] = dir_rentry[gen_i].tag;
 
         assign req_hit[gen_i]   = (dir_tags[gen_i] == dir_match_tag_i);
-        assign cmo_hit[gen_i]   = (dir_tags[gen_i] == dir_cmo_check_nline_tag_i);
         assign inval_hit[gen_i] = (dir_tags[gen_i] == dir_inval_tag);
 
         assign dir_hit_way_o[gen_i]                 = dir_valid[gen_i] & req_hit[gen_i];
-        assign dir_cmo_check_nline_hit_way_o[gen_i] = dir_valid[gen_i] & cmo_hit[gen_i];
         assign dir_inval_hit_way[gen_i]             = dir_valid[gen_i] & inval_hit[gen_i];
     end
 
@@ -674,8 +656,6 @@ import hpdcache_pkg::*;
     assign dir_hit_dirty_o = |(dir_hit_way_o & dir_dirty);
     assign dir_hit_fetch_o = |(dir_hit_way_o & dir_fetch);
 
-    assign dir_cmo_check_nline_wback_o = |(dir_cmo_check_nline_hit_way_o & dir_wback);
-    assign dir_cmo_check_nline_dirty_o = |(dir_cmo_check_nline_hit_way_o & dir_dirty);
     assign dir_cmo_check_entry_valid_o = |(dir_req_way_q & dir_valid);
     assign dir_cmo_check_entry_wback_o = |(dir_req_way_q & dir_wback);
     assign dir_cmo_check_entry_dirty_o = |(dir_req_way_q & dir_dirty);
@@ -1038,7 +1018,7 @@ import hpdcache_pkg::*;
             dir_req_set_q <= '0;
             dir_req_way_q <= '0;
         end else begin
-            if (dir_match_i || dir_cmo_check_nline_i || dir_inval_check_i) begin
+            if (dir_match_i || dir_inval_check_i) begin
                 dir_req_set_q <= dir_addr;
             end
             if (dir_cmo_check_entry_i) begin
@@ -1142,7 +1122,6 @@ import hpdcache_pkg::*;
                       dir_refill_i,
                       dir_inval_check_i,
                       dir_inval_write_i,
-                      dir_cmo_check_nline_i,
                       dir_cmo_check_entry_i,
                       dir_cmo_updt_i,
                       dir_updt_i,

--- a/rtl/src/hpdcache_pkg.sv
+++ b/rtl/src/hpdcache_pkg.sv
@@ -336,13 +336,9 @@ package hpdcache_pkg;
     //  Definition of constants and types for the CMO request handler (CMOH)
     //  {{{
     typedef struct packed {
-        logic is_flush_inval_by_nline;
         logic is_flush_inval_all;
-        logic is_flush_by_nline;
         logic is_flush_all;
-        logic is_inval_by_nline;
         logic is_inval_all;
-        logic is_fence;
     } hpdcache_cmoh_op_t;
     //  }}}
 

--- a/rtl/src/hpdcache_uncached.sv
+++ b/rtl/src/hpdcache_uncached.sv
@@ -64,11 +64,6 @@ import hpdcache_pkg::*;
     input  hpdcache_req_data_t    req_old_data_i,
     //  }}}
 
-    //  Write buffer interface
-    //  {{{
-    output logic                  wbuf_flush_all_o,
-    //  }}}
-
     //  AMO Cache Interface
     //  {{{
     output logic                  data_amo_write_o,
@@ -297,7 +292,6 @@ import hpdcache_pkg::*;
         rsp_error_rst          = 1'b0;
         lrsc_rsrv_addr_d       = lrsc_rsrv_addr_q;
         uc_sc_retcode_d        = uc_sc_retcode_q;
-        wbuf_flush_all_o       = 1'b0;
         lrsc_uc_set            = 1'b0;
         lrsc_uc_reset          = 1'b0;
 
@@ -309,8 +303,6 @@ import hpdcache_pkg::*;
             UC_IDLE: begin
 
                 if (req_valid_i) begin
-                    wbuf_flush_all_o = 1'b1;
-
                     unique case (1'b1)
                         req_op_i.is_ld,
                         req_op_i.is_st: begin

--- a/rtl/tb/hpdcache_wrapper.sv
+++ b/rtl/tb/hpdcache_wrapper.sv
@@ -402,14 +402,14 @@ import hpdcache_pkg::*;
                     i_hpdcache.hpdcache_ctrl_i.hpdcache_ctrl_pe_i.st1_req_valid_i &&
                     i_hpdcache.hpdcache_ctrl_i.hpdcache_ctrl_pe_i.st1_req_is_store_i &&
                     i_hpdcache.hpdcache_ctrl_i.hpdcache_ctrl_pe_i.st1_req_is_partial_i &&
-                    i_hpdcache.hpdcache_ctrl_i.hpdcache_ctrl_pe_i.cachedir_hit_i &&
+                    i_hpdcache.hpdcache_ctrl_i.hpdcache_ctrl_pe_i.st1_dir_hit_i &&
                     i_hpdcache.hpdcache_ctrl_i.hpdcache_ctrl_pe_i.st1_req_cachedata_write_enable_o);
         partial_amo_hit_cover: cover property (
             @(posedge clk_i) disable iff (rst_ni !== 1'b1)
                     i_hpdcache.hpdcache_ctrl_i.hpdcache_ctrl_pe_i.st1_req_valid_i &&
                     i_hpdcache.hpdcache_ctrl_i.hpdcache_ctrl_pe_i.st1_req_is_amo_i &&
                     i_hpdcache.hpdcache_ctrl_i.hpdcache_ctrl_pe_i.st1_req_is_partial_i &&
-                    i_hpdcache.hpdcache_ctrl_i.hpdcache_ctrl_pe_i.cachedir_hit_i &&
+                    i_hpdcache.hpdcache_ctrl_i.hpdcache_ctrl_pe_i.st1_dir_hit_i &&
                     i_hpdcache.hpdcache_ctrl_i.hpdcache_ctrl_pe_i.uc_req_valid_o);
     end
 `endif

--- a/rtl/tb/scripts/smoke_tests.sh
+++ b/rtl/tb/scripts/smoke_tests.sh
@@ -15,29 +15,37 @@ LINT_DIR=$(readlink -f ${SCRIPT_DIR}/../../lint)
 NTRANS=$((16*1024))
 NTESTS=8
 SEQUENCES=(random)
-USER_ARGS=$*
 CONFIGS=(configs/directmap_config.mk
          configs/embedded_config.mk
          configs/hpc_config.mk
          configs/default_config.mk)
 
-(
+DO_LINT=1
+if [[ $1 == '--no-lint' ]] ; then
+    DO_LINT=0
+    shift
+fi
+USER_ARGS=$*
+
+if [[ ${DO_LINT} == 1 ]] ; then
     cd ${TEST_DIR}
     printf "Checking formatting of testbench C++ sources in ${TEST_DIR}\n"
     ./scripts/check_format_tb.sh
-)
-ret=$?
-if [[ ${ret} != 0 ]] ; then
-    printf "FAILURE: there are formatting issues in C++ testbench files\n"
-    exit 1 ;
+    ret=$?
+    if [[ ${ret} != 0 ]] ; then
+        printf "FAILURE: there are formatting issues in C++ testbench files\n"
+        exit 1 ;
+    fi
 fi
 
 for c in ${CONFIGS[@]} ; do
-    make -s -C ${LINT_DIR} verible-lint
-    ret=$?
-    if [[ ${ret} != 0 ]] ; then
-        printf "FAILURE: there are linting errors\n"
-        exit 1 ;
+    if [[ ${DO_LINT} == 1 ]] ; then
+        make -s -C ${LINT_DIR} verible-lint
+        ret=$?
+        if [[ ${ret} != 0 ]] ; then
+            printf "FAILURE: there are linting errors\n"
+            exit 1 ;
+        fi
     fi
 
     for s in ${SEQUENCES[@]} ; do

--- a/rtl/tb/sequence_lib/hpdcache_test_random_seq.h
+++ b/rtl/tb/sequence_lib/hpdcache_test_random_seq.h
@@ -88,10 +88,14 @@ public:
             hpdcache_test_transaction_req::HPDCACHE_REQ_CMO_FENCE, 10);
         hpdcache_test_sequence::op_distribution.push(
             hpdcache_test_transaction_req::HPDCACHE_REQ_CMO_PREFETCH, 10);
-        //        hpdcache_test_sequence::op_distribution.push(hpdcache_test_transaction_req::HPDCACHE_REQ_CMO_INVAL_NLINE,
-        //        15);
-        //        hpdcache_test_sequence::op_distribution.push(hpdcache_test_transaction_req::HPDCACHE_REQ_CMO_INVAL_ALL,
-        //        15);
+
+#if !defined(CONF_HPDCACHE_WB_ENABLE) || (CONF_HPDCACHE_WB_ENABLE == 0)
+        hpdcache_test_sequence::op_distribution.push(
+            hpdcache_test_transaction_req::HPDCACHE_REQ_CMO_INVAL_NLINE, 15);
+        hpdcache_test_sequence::op_distribution.push(
+            hpdcache_test_transaction_req::HPDCACHE_REQ_CMO_INVAL_ALL, 15);
+#endif
+
         hpdcache_test_sequence::op_distribution.push(
             hpdcache_test_transaction_req::HPDCACHE_REQ_CMO_FLUSH_NLINE, 10);
         hpdcache_test_sequence::op_distribution.push(


### PR DESCRIPTION
When a CMO is received, if there are any pending transactions in the cache, the CMO is stored in the Replay Table. It waits there until all pending transactions are committed. Only then is the CMO replayed.

This PR also adds the processing of CMOs directly in the pipeline. Only full-cache CMOs (INVAL ALL / FLUSH ALL) go through the dedicated CMO FSM.